### PR TITLE
perf: call datasetsService concurrently for pids in publisheddata

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,9 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.88.1
 	github.com/aws/aws-sdk-go-v2/service/sts v1.38.4
 	github.com/gin-gonic/gin v1.9.1
+	github.com/google/go-cmp v0.7.0
 	github.com/oapi-codegen/runtime v1.1.2
+	golang.org/x/sync v0.9.0
 )
 
 require (
@@ -40,7 +42,6 @@ require (
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/go-playground/validator/v10 v10.14.1 // indirect
 	github.com/goccy/go-json v0.10.2 // indirect
-	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/uuid v1.5.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
@@ -66,7 +67,6 @@ require (
 	golang.org/x/crypto v0.27.0 // indirect
 	golang.org/x/mod v0.21.0 // indirect
 	golang.org/x/net v0.29.0 // indirect
-	golang.org/x/sync v0.9.0 // indirect
 	golang.org/x/sys v0.25.0 // indirect
 	golang.org/x/text v0.20.0 // indirect
 	golang.org/x/tools v0.25.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -98,8 +98,6 @@ github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
-github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=

--- a/internal/scicat/published_data_service.go
+++ b/internal/scicat/published_data_service.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/paulscherrerinstitute/scicat-s3-broker/internal/api"
 	"github.com/paulscherrerinstitute/scicat-s3-broker/internal/config"
+	"golang.org/x/sync/errgroup"
 )
 
 type PublisheddataService interface {
@@ -54,13 +55,28 @@ func (s *PublisheddataServiceImpl) GetUrls(ctx context.Context, doi string) (api
 	if len(publishedDataResp) == 0 {
 		return nil, PublishedDataNotFoundError{Id: doi}
 	}
+	type concurrentResult struct {
+		pid            string
+		datasetUrlResp api.DatasetsUrlResponse
+	}
+	resultSlice := make([]concurrentResult, len(publishedDataResp[0].DatasetPids))
+	g, ctx := errgroup.WithContext(ctx)
+	for i, pid := range publishedDataResp[0].DatasetPids {
+		g.Go(func() error {
+			urls, err := s.datasetsService.GetUrls(ctx, pid)
+			if err == nil {
+				resultSlice[i] = concurrentResult{pid, urls}
+				return nil
+			}
+			return fmt.Errorf("failed to get URLs for dataset %s: %w", pid, err)
+		})
+	}
+	if err = g.Wait(); err != nil {
+		return nil, fmt.Errorf("error from a goroutine executing datasetsService.GetUrls: %w", err)
+	}
 	result := make(api.PublishedDataUrlsResponse)
-	for _, pid := range publishedDataResp[0].DatasetPids {
-		urls, err := s.datasetsService.GetUrls(ctx, pid)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get URLs for dataset %s: %w", pid, err)
-		}
-		result[pid] = urls
+	for _, r := range resultSlice {
+		result[r.pid] = r.datasetUrlResp
 	}
 	return result, nil
 }

--- a/internal/scicat/published_data_service_test.go
+++ b/internal/scicat/published_data_service_test.go
@@ -14,24 +14,27 @@ import (
 	"github.com/paulscherrerinstitute/scicat-s3-broker/internal/config"
 )
 
-type mockDatasetsServiceImpl struct {
-	err error
-	val map[string]api.DatasetsUrlResponse
-}
+type mockDatasetsServiceImpl struct{}
+
+var errMockDatasetsInternal = errors.New("internal error")
 
 func (m *mockDatasetsServiceImpl) GetUrls(c context.Context, dataset string) (api.DatasetsUrlResponse, error) {
-	if m.err != nil {
-		return nil, m.err
+	switch dataset {
+	case "pid1":
+		return api.DatasetsUrlResponse{{Url: "http://example.com/pid1"}}, nil
+	case "pid2":
+		return api.DatasetsUrlResponse{{Url: "http://example.com/pid2"}}, nil
+	case "pid-no-urls":
+		return nil, NoUrlsAvailableError{Pid: dataset}
+	default:
+		return nil, errMockDatasetsInternal
 	}
-	return m.val[dataset], nil
 }
 
 func TestPublisheddataServiceGetUrls(t *testing.T) {
 	tests := []struct {
 		name           string
 		serverResponse func(w http.ResponseWriter, r *http.Request)
-		mockVal        map[string]api.DatasetsUrlResponse
-		mockErr        error
 		wantErr        bool
 		wantErrIs      error
 		wantResult     api.PublishedDataUrlsResponse
@@ -44,10 +47,6 @@ func TestPublisheddataServiceGetUrls(t *testing.T) {
 					{DatasetPids: []string{"pid1", "pid2"}},
 				})
 			},
-			mockVal: map[string]api.DatasetsUrlResponse{
-				"pid1": {{Url: "http://example.com/pid1"}},
-				"pid2": {{Url: "http://example.com/pid2"}},
-			},
 			wantErr: false,
 			wantResult: map[string]api.DatasetsUrlResponse{
 				"pid1": {{Url: "http://example.com/pid1"}},
@@ -55,7 +54,7 @@ func TestPublisheddataServiceGetUrls(t *testing.T) {
 			},
 		},
 		{
-			name: "404 Not Found",
+			name: "Non OK status code from scicat gets publisheddata",
 			serverResponse: func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusNotFound)
 			},
@@ -84,12 +83,22 @@ func TestPublisheddataServiceGetUrls(t *testing.T) {
 			serverResponse: func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				json.NewEncoder(w).Encode([]SciCatPublishedDataItem{
-					{DatasetPids: []string{"pid1"}},
+					{DatasetPids: []string{"pid-no-urls"}},
 				})
 			},
-			mockErr:   NoUrlsAvailableError{"pid1"},
 			wantErr:   true,
-			wantErrIs: NoUrlsAvailableError{"pid1"},
+			wantErrIs: NoUrlsAvailableError{"pid-no-urls"},
+		},
+		{
+			name: "Mix of success and error responses from datasets service",
+			serverResponse: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode([]SciCatPublishedDataItem{
+					{DatasetPids: []string{"error-pid", "pid1"}},
+				})
+			},
+			wantErr:   true,
+			wantErrIs: errMockDatasetsInternal,
 		},
 	}
 
@@ -99,11 +108,8 @@ func TestPublisheddataServiceGetUrls(t *testing.T) {
 			defer server.Close()
 
 			svc := PublisheddataServiceImpl{
-				config: &config.Config{SciCatURL: server.URL},
-				datasetsService: &mockDatasetsServiceImpl{
-					err: tt.mockErr,
-					val: tt.mockVal,
-				},
+				config:          &config.Config{SciCatURL: server.URL},
+				datasetsService: &mockDatasetsServiceImpl{},
 			}
 
 			result, err := svc.GetUrls(context.Background(), "test-doi")


### PR DESCRIPTION
Make calls to datasetsService.GetUrls concurrent.

We launch the goroutines in an [errgroup](https://pkg.go.dev/golang.org/x/sync/errgroup#example-Group-Parallel) - this has the behavior that if any goroutine returns an error, all other goroutines in the errgroup are cancelled and g.Wait() returns with the underlying error.

Each goroutine writes its result to a predetermined index into a "results" slice (following the pattern from above link), hence there is no data race. Whereas writing directly to the map would not be thread safe.

For a publisheddata with two datasets `publisheddata/urls?id=10.83766%2Fde001ddf-79ff-42ff-b232-f1b7a8bd2aca` we see an improvement from 190ms to 130ms - which would likely be more significant when there are 10s of datasets.

(also ran `go mod tidy` to fix some dependency warnings)
 