### PR TITLE
fix: return expiration in past in case no urls found

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -27,7 +27,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
         "404":
-          description: No URLs available for the dataset, trigger a URL retrieve job in SciCat
+          description: Dataset not found
           content:
             application/json:
               schema:
@@ -68,7 +68,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
         "404":
-          description: Either publisheddata with `id` not found. Or no URLs available for on or more datasets in the publisheddata
+          description: Either publisheddata with `id` not found. Or one or more datasets in the publisheddata not found
           content:
             application/json:
               schema:

--- a/internal/scicat/datasets_handler.go
+++ b/internal/scicat/datasets_handler.go
@@ -17,15 +17,15 @@ func (h *DatasetsHandler) GetDatasetsUrls(c *gin.Context, id api.GetDatasetsUrls
 	datasetsUrlResp, err := h.service.GetUrls(c.Request.Context(), id.Pid)
 
 	if err != nil {
-		var datasetErr DatasetNotAccessibleError
-		var noUrlsErr NoUrlsAvailableError
+		var notAccErr DatasetNotAccessibleError
+		var notFoundErr DatasetNotFoundError
 		switch {
-		case errors.As(err, &datasetErr):
+		case errors.As(err, &notAccErr):
 			log.Println(err)
-			c.JSON(http.StatusForbidden, gin.H{"error": datasetErr.Error()})
-		case errors.As(err, &noUrlsErr):
+			c.JSON(http.StatusForbidden, gin.H{"error": notAccErr.Error()})
+		case errors.As(err, &notFoundErr):
 			log.Println(err)
-			c.JSON(http.StatusNotFound, gin.H{"error": noUrlsErr.Error()})
+			c.JSON(http.StatusNotFound, gin.H{"error": notFoundErr.Error()})
 		default:
 			log.Println(err)
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal server error"})

--- a/internal/scicat/datasets_handler_test.go
+++ b/internal/scicat/datasets_handler_test.go
@@ -16,11 +16,9 @@ type mockService struct{}
 func (m *mockService) GetUrls(c context.Context, dataset string) (*api.DatasetsUrlResponse, error) {
 	switch dataset {
 	case "not-found":
-		return nil, DatasetNotAccessibleError{dataset}
+		return nil, DatasetNotFoundError{dataset}
 	case "forbidden":
 		return nil, DatasetNotAccessibleError{dataset}
-	case "no-urls":
-		return nil, NoUrlsAvailableError{dataset}
 	case "internal-error":
 		return nil, fmt.Errorf("internal error")
 	default:
@@ -49,17 +47,12 @@ func TestDatasetsHandler_GetDatasetsUrls(t *testing.T) {
 		{
 			name:       "Dataset Not Accessible",
 			pid:        "not-found",
-			wantStatus: http.StatusForbidden,
+			wantStatus: http.StatusNotFound,
 		},
 		{
 			name:       "Dataset Not Accessible (forbidden)",
 			pid:        "forbidden",
 			wantStatus: http.StatusForbidden,
-		},
-		{
-			name:       "No URLs Available",
-			pid:        "no-urls",
-			wantStatus: http.StatusNotFound,
 		},
 		{
 			name:       "Internal Server Error",

--- a/internal/scicat/datasets_service.go
+++ b/internal/scicat/datasets_service.go
@@ -43,10 +43,12 @@ type SciCatLoginResponse struct {
 	CreatedAt   string `json:"created"`
 }
 
+var unixEpoch = time.Unix(0, 0).UTC()
+
 func (s *DatasetsServiceImpl) GetUrls(c context.Context, dataset string) (*api.DatasetsUrlResponse, error) {
 
-	if !s.isPublic(dataset) {
-		return nil, DatasetNotAccessibleError{dataset}
+	if err := s.isPublicAndExists(dataset); err != nil {
+		return nil, err
 	}
 
 	accessToken, err := s.getToken()
@@ -92,7 +94,7 @@ func (s *DatasetsServiceImpl) GetUrls(c context.Context, dataset string) (*api.D
 	}
 
 	if len(jobResp) == 0 {
-		return nil, NoUrlsAvailableError{dataset}
+		return &api.DatasetsUrlResponse{Expires: unixEpoch, Urls: []api.UrlInfo{}}, nil
 	}
 
 	datasetsUrlResp, err := toDatasetsUrlResponse(dataset, jobResp[0])
@@ -195,16 +197,15 @@ func (s *DatasetsServiceImpl) isTokenExpired() bool {
 	return time.Now().Add(10 * time.Minute).After(expirationTime)
 }
 
-func (s *DatasetsServiceImpl) isPublic(datasetPid string) bool {
+func (s *DatasetsServiceImpl) isPublicAndExists(datasetPid string) error {
 	filterQuery, err := json.Marshal(gin.H{"fields": []string{"_id"}})
 	if err != nil {
-		return false
+		return fmt.Errorf("failed to marshal request to /datasets: %w", err)
 	}
 
 	u, err := url.Parse(fmt.Sprintf("%s/api/v3/datasets/%s", s.config.SciCatURL, url.PathEscape(datasetPid)))
 	if err != nil {
-		log.Printf("failed to parse dataset URL: %v", err)
-		return false
+		return fmt.Errorf("failed to parse dataset URL: %w", err)
 	}
 	q := u.Query()
 	q.Set("filter", string(filterQuery))
@@ -212,12 +213,20 @@ func (s *DatasetsServiceImpl) isPublic(datasetPid string) bool {
 
 	resp, err := http.Get(u.String())
 	if err != nil {
-		log.Printf("failed to check dataset public status: %v", err)
-		return false
+		return fmt.Errorf("failed to check dataset public status: %w", err)
 	}
 	defer resp.Body.Close()
 
-	return resp.StatusCode == http.StatusOK
+	switch resp.StatusCode {
+	case http.StatusOK:
+		return nil
+	case http.StatusNotFound:
+		return DatasetNotFoundError{datasetPid}
+	case http.StatusForbidden:
+		return DatasetNotAccessibleError{datasetPid}
+	default:
+		return fmt.Errorf("Unexpected status code from /datsets: %v", resp.StatusCode)
+	}
 }
 
 func (s *DatasetsServiceImpl) getToken() (string, error) {

--- a/internal/scicat/datasets_service_test.go
+++ b/internal/scicat/datasets_service_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/paulscherrerinstitute/scicat-s3-broker/internal/api"
 	"github.com/paulscherrerinstitute/scicat-s3-broker/internal/config"
 )
@@ -55,9 +56,16 @@ func TestDatasetsServiceGetUrls(t *testing.T) {
 		{
 			name:           "Dataset Not Public",
 			datasetPid:     "private-pid",
-			mockPublicCode: http.StatusNotFound,
+			mockPublicCode: http.StatusForbidden,
 			wantErr:        true,
 			wantErrIs:      DatasetNotAccessibleError{"private-pid"},
+		},
+		{
+			name:           "Dataset Not Found",
+			datasetPid:     "no-such-pid",
+			mockPublicCode: http.StatusNotFound,
+			wantErr:        true,
+			wantErrIs:      DatasetNotFoundError{"no-such-pid"},
 		},
 		{
 			name:           "Login Failed",
@@ -81,8 +89,8 @@ func TestDatasetsServiceGetUrls(t *testing.T) {
 			mockLoginCode:  http.StatusCreated,
 			mockJobsCode:   http.StatusOK,
 			mockJobsBody:   `[]`,
-			wantErr:        true,
-			wantErrIs:      NoUrlsAvailableError{"valid-pid"},
+			wantErr:        false,
+			wantResult:     api.DatasetsUrlResponse{},
 		},
 	}
 
@@ -138,8 +146,13 @@ func TestDatasetsServiceGetUrls(t *testing.T) {
 				}
 			}
 
-			if !tt.wantErr && result.Urls[0].Url != tt.wantResult.Urls[0].Url {
-				t.Errorf("GetUrls() mismatch\ngot:  %+v\nwant: %+v", result, tt.wantResult)
+			if !tt.wantErr {
+				expectedNoJobsResp := api.DatasetsUrlResponse{Expires: unixEpoch, Urls: []api.UrlInfo{}}
+				if len(result.Urls) > 0 && result.Urls[0].Url != tt.wantResult.Urls[0].Url {
+					t.Errorf("GetUrls() mismatch\ngot:  %+v\nwant: %+v", result, tt.wantResult)
+				} else if tt.name == "No Jobs Found" && !cmp.Equal(*result, expectedNoJobsResp) {
+					t.Errorf("GetUrls() mismatch:\ndiff %v", cmp.Diff(*result, expectedNoJobsResp))
+				}
 			}
 		})
 	}
@@ -158,7 +171,7 @@ func TestToDatasetsUrlResponse(t *testing.T) {
 		expectedCount int
 	}{
 		{
-			name: "Valid Single Result",
+			name: "Valid Result",
 			pid:  "pid-123",
 			inputJSON: fmt.Sprintf(`{
 				"jobResultObject": {

--- a/internal/scicat/errors.go
+++ b/internal/scicat/errors.go
@@ -6,15 +6,15 @@ type DatasetNotAccessibleError struct {
 	Pid string
 }
 
-type NoUrlsAvailableError struct {
+type DatasetNotFoundError struct {
 	Pid string
 }
 
 func (e DatasetNotAccessibleError) Error() string {
 	return fmt.Sprintf("Dataset %s not accessible", e.Pid)
 }
-func (e NoUrlsAvailableError) Error() string {
-	return fmt.Sprintf("No URLs available for %s. Trigger a URL retrieve job in SciCat", e.Pid)
+func (e DatasetNotFoundError) Error() string {
+	return fmt.Sprintf("Dataset with PID %s not found.", e.Pid)
 }
 
 type PublishedDataNotFoundError struct {

--- a/internal/scicat/published_data_service_test.go
+++ b/internal/scicat/published_data_service_test.go
@@ -28,7 +28,7 @@ func (m *mockDatasetsServiceImpl) GetUrls(c context.Context, dataset string) (*a
 	case "pid2":
 		return &api.DatasetsUrlResponse{Expires: timeB, Urls: []api.UrlInfo{{Url: "http://example.com/pid2"}}}, nil
 	case "pid-no-urls":
-		return nil, NoUrlsAvailableError{Pid: dataset}
+		return nil, DatasetNotFoundError{Pid: dataset}
 	default:
 		return nil, errMockDatasetsInternal
 	}
@@ -93,7 +93,7 @@ func TestPublisheddataServiceGetUrls(t *testing.T) {
 				})
 			},
 			wantErr:   true,
-			wantErrIs: NoUrlsAvailableError{"pid-no-urls"},
+			wantErrIs: DatasetNotFoundError{"pid-no-urls"},
 		},
 		{
 			name: "Mix of success and error responses from datasets service",

--- a/internal/scicat/publisheddata_handler.go
+++ b/internal/scicat/publisheddata_handler.go
@@ -18,7 +18,7 @@ func (h *PublisheddataHandler) GetPublisheddataUrls(c *gin.Context, params api.G
 	if err != nil {
 		log.Println(err)
 		var datasetNotAccErr DatasetNotAccessibleError
-		var noUrlsErr NoUrlsAvailableError
+		var noUrlsErr DatasetNotFoundError
 		var pubDataErr PublishedDataNotFoundError
 		switch {
 		case errors.As(err, &pubDataErr):

--- a/internal/scicat/publisheddata_handler_test.go
+++ b/internal/scicat/publisheddata_handler_test.go
@@ -18,9 +18,9 @@ func (m *mockPublisheddataSvc) GetUrls(ctx context.Context, doi string) (*api.Pu
 	case "not-found":
 		return nil, PublishedDataNotFoundError{Id: doi}
 	case "forbidden":
-		return nil, DatasetNotAccessibleError{doi}
-	case "no-urls":
-		return nil, NoUrlsAvailableError{doi}
+		return nil, DatasetNotAccessibleError{"test-pid"}
+	case "dataset-not-found":
+		return nil, DatasetNotFoundError{"test-pid"}
 	case "internal-error":
 		return nil, errors.New("internal error")
 	default:
@@ -51,8 +51,8 @@ func TestGetPublisheddataUrls(t *testing.T) {
 			wantStatus: http.StatusForbidden,
 		},
 		{
-			name:       "NoUrlsAvailableError",
-			doi:        "no-urls",
+			name:       "DatasetNotFoundError",
+			doi:        "dataset-not-found",
 			wantStatus: http.StatusNotFound,
 		},
 		{


### PR DESCRIPTION
Before, we returned 404 in case no URLs were found. Return an expiration in past (unix epoch) and emtpy URL list (`[]`, _not_ `null`) with 200 now.

Also distinguish between forbidden and not found datasets.

See [comment](https://github.com/paulscherrerinstitute/scicat-s3-broker/pull/12#discussion_r2911800366) on previous PR for additional context

### 1. Public, but no URLs:
`GET /datasets/urls?pid=20.500.11935/3053d988-8d83-45d6-a3f9-e4ba1abd1710`

200 OK
```json
{"expires":"1970-01-01T00:00:00Z","urls":[]}
```
### 2. Not public
`GET /datasets/urls?pid=20.500.11935/4a49d548-4b9a-4099-bdb4-1c9a284bdbfa`

403 Forbidden
```json
{"error":"Dataset 20.500.11935/4a49d548-4b9a-4099-bdb4-1c9a284bdbfa not accessible"}
```

### 3. Not found
`GET datasets/urls?pid=xyze34234`

404 Not found
```json
{"error":"Dataset with PID xyze34234 not found."}
```