### PR TITLE
chore: update renovate config. add verify no new diff on generate/tidy

### DIFF
--- a/.github/workflows/go-build-test.yml
+++ b/.github/workflows/go-build-test.yml
@@ -2,24 +2,30 @@ name: Go build/test
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
 
 jobs:
-
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+      - uses: actions/checkout@v6
 
-    - name: Set up Go
-      uses: actions/setup-go@v6
-      with:
-        go-version-file: 'go.mod'
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: "go.mod"
 
-    - name: Build
-      run: go build -v ./...
+      - name: Generate and Verify
+        run: |
+          go mod tidy
+          go generate -v ./...
+          go mod tidy        
+          git diff --exit-code
 
-    - name: Test
-      run: go test -v -race -cover ./...
+      - name: Build
+        run: go build -v ./...
+
+      - name: Test
+        run: go test -v -race -cover ./...

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "postUpdateOptions": [
+    "gomodTidy"
   ]
 }


### PR DESCRIPTION
This PR updates renovate config and CI to mitigate and catch issues with dependency updates. See [comment](https://github.com/paulscherrerinstitute/scicat-s3-broker/pull/16#issuecomment-4046371068) on the last PR

- Update renovate config to also run `go mod tidy`.
- Verify in CI that `go generate` + `go mod tidy` does not produce any new diff: if it does, it probably means the update needs manual attention.