### PR TITLE
chore: update to go1.26.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Also included is a simple CLI client that can be used as an AWS CLI credential p
 
 ### Prerequisites
 
-- Go 1.25+
+- Go 1.26+
 - SciCat backend instance
 - Ceph or AWS-compatible S3 backend with STS enabled
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/paulscherrerinstitute/scicat-s3-broker
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.41.4

--- a/internal/scicat/datasets_handler.go
+++ b/internal/scicat/datasets_handler.go
@@ -17,16 +17,13 @@ func (h *DatasetsHandler) GetDatasetsUrls(c *gin.Context, id api.GetDatasetsUrls
 	datasetsUrlResp, err := h.service.GetUrls(c.Request.Context(), id.Pid)
 
 	if err != nil {
-		var notAccErr DatasetNotAccessibleError
-		var notFoundErr DatasetNotFoundError
-		switch {
-		case errors.As(err, &notAccErr):
+		if notAccErr, ok := errors.AsType[DatasetNotAccessibleError](err); ok {
 			log.Println(err)
 			c.JSON(http.StatusForbidden, gin.H{"error": notAccErr.Error()})
-		case errors.As(err, &notFoundErr):
+		} else if notFoundErr, ok := errors.AsType[DatasetNotFoundError](err); ok {
 			log.Println(err)
 			c.JSON(http.StatusNotFound, gin.H{"error": notFoundErr.Error()})
-		default:
+		} else {
 			log.Println(err)
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal server error"})
 		}

--- a/internal/scicat/datasets_service_test.go
+++ b/internal/scicat/datasets_service_test.go
@@ -100,7 +100,7 @@ func TestDatasetsServiceGetUrls(t *testing.T) {
 				if r.URL.Path == "/api/v3/auth/login" && r.Method == "POST" {
 					if tt.mockLoginCode == http.StatusCreated {
 						w.WriteHeader(http.StatusCreated)
-						json.NewEncoder(w).Encode(map[string]interface{}{
+						json.NewEncoder(w).Encode(map[string]any{
 							"access_token": "dummy-token",
 							"expires_in":   3600,
 							"created":      now.Format(time.RFC3339),

--- a/internal/scicat/publisheddata_handler.go
+++ b/internal/scicat/publisheddata_handler.go
@@ -17,17 +17,13 @@ func (h *PublisheddataHandler) GetPublisheddataUrls(c *gin.Context, params api.G
 	result, err := h.service.GetUrls(c.Request.Context(), params.Id)
 	if err != nil {
 		log.Println(err)
-		var datasetNotAccErr DatasetNotAccessibleError
-		var noUrlsErr DatasetNotFoundError
-		var pubDataErr PublishedDataNotFoundError
-		switch {
-		case errors.As(err, &pubDataErr):
+		if pubDataErr, ok := errors.AsType[PublishedDataNotFoundError](err); ok {
 			c.JSON(http.StatusNotFound, gin.H{"error": pubDataErr.Error()})
-		case errors.As(err, &datasetNotAccErr):
+		} else if datasetNotAccErr, ok := errors.AsType[DatasetNotAccessibleError](err); ok {
 			c.JSON(http.StatusForbidden, gin.H{"error": datasetNotAccErr.Error()})
-		case errors.As(err, &noUrlsErr):
+		} else if noUrlsErr, ok := errors.AsType[DatasetNotFoundError](err); ok {
 			c.JSON(http.StatusNotFound, gin.H{"error": noUrlsErr.Error()})
-		default:
+		} else {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal server error"})
 		}
 		return


### PR DESCRIPTION
- updated go.mod to 1.26.0 (the go toolchain in Dockerfile was updated by renovate in #15 )
- using [error.AsType](https://pkg.go.dev/errors#AsType) introduced in 1.26.0 in favor of the older slightly verbose style where one had to declare all error variables beforehand