### PR TITLE
Feature: add /upload-session endpoint for presigned PUT/GET URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Also included is a simple CLI client that can be used as an AWS CLI credential p
 
 - 🔑 **Credential broker**: returns temporary S3 credentials for a given dataset.
 - 📥 **Download URLs** for public datasets: get presigned URLs for retrieved, public datasets.
+- 📤 **Upload sessions**: get a pair of presigned PUT/GET URLs for a fresh random object path with a tiered expiry (1d/3d/7d).
 - 🛡 **Authorization via SciCat**: forwards the end-user’s SciCat token for access checks. //TO-DO
 
 ---
@@ -31,14 +32,16 @@ The following environement variables are available for configuration:
 
 | env var              | required | default    | description                                                 | example                            |
 | -------------------- | -------- | ---------- | ----------------------------------------------------------- | ---------------------------------- |
-| SCICAT_URL           | yes      |            | SciCat backend base url                                     | https://scicat.development.psi.ch/ |
+| SCICAT_URL           | no\*     |            | SciCat backend base url                                     | https://scicat.development.psi.ch/ |
 | JOB_MANAGER_USERNAME | no       | jobManager | credentials for functional account to query /jobs in SciCat |                                    |
 | JOB_MANAGER_PASSWORD | no\*     | ""         |                                                             |                                    |
+| S3_BUCKET            | no\*\*   |            | Bucket used by `/upload-session` for storing uploads        | aiidalab-exchange                  |
 | PORT                 | no       | 8080       | The port to serve from. This is a Gin configuration         |                                    |
 | GIN_MODE             | no       | debug      | Set to `release` for production                             |                                    |
 
-\* JOB_MANAGER_PASSWORD is _required_ for the `/datasets/urls` endpoint. If not set, the server returns `HTTP 501 Not Implemented`.
-It is not required for the `/datasets/s3-creds` endpoint.
+\* `SCICAT_URL` and `JOB_MANAGER_PASSWORD` are _required_ for the `/datasets/urls` endpoint. If either is missing, the server returns `HTTP 501 Not Implemented` for that endpoint. They are not required for `/datasets/s3-creds` or `/upload-session`.
+
+\*\* `S3_BUCKET` is _required_ for the `/upload-session` endpoint. If not set, that endpoint returns `HTTP 500`.
 
 #### AWS Config
 The AWS shared config and credentials files are in [env/](./env) directory. Copy `credentials.example` to `credentials` and replace with your secret / access key.
@@ -74,6 +77,42 @@ Response:
   "expiry_time": "2025-09-09T16:20:00Z"
 }
 ```
+
+###### /upload-session
+
+```bash
+# default (1 day)
+curl "http://localhost:8080/upload-session?filename=myfile.dat"
+
+# 3 days
+curl "http://localhost:8080/upload-session?filename=myfile.dat&expiry=3d"
+
+# 7 days
+curl "http://localhost:8080/upload-session?filename=myfile.dat&expiry=7d"
+```
+
+Response:
+
+```json
+{
+  "upload_url": "https://rgw.example.com/bucket/d1/<random>/myfile.dat?X-Amz-...",
+  "download_url": "https://rgw.example.com/bucket/d1/<random>/myfile.dat?X-Amz-...",
+  "path": "d1/<random>/myfile.dat",
+  "expires": "2026-05-07T00:00:00Z"
+}
+```
+
+Then:
+
+```bash
+# User1 uploads
+curl -X PUT -T myfile.dat "<upload_url>"
+
+# User2 downloads
+curl "<download_url>" -o myfile.dat
+```
+
+Files are stored under `d1/`, `d3/`, or `d7/` prefixes inside `S3_BUCKET` based on the requested expiry. Configure matching S3 lifecycle rules on the bucket so objects are automatically deleted after 1, 3, or 7 days respectively.
 
 ###### /datasets/urls
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -17,18 +17,18 @@ func main() {
 		log.Fatalf("Failed to load configuration: %v", err)
 	}
 
-	s3Handler := s3.NewHandler()
+	s3Handler := s3.NewHandler(cfg)
 
 	router.GET("/health", func(c *gin.Context) {
-		c.JSON(200, gin.H{
-			"status": "healthy",
-		})
+		c.JSON(200, gin.H{"status": "healthy"})
 	})
+	router.GET("/upload-session", s3Handler.CreateUploadSession)
+
 	type SciCatHandler = scicat.Handler
 	type SciCatNotImplHandler = scicat.NotImplHandler
 	type S3Handler = s3.Handler
 
-	if cfg.JobManagerPassword != "" {
+	if cfg.SciCatURL != "" && cfg.JobManagerPassword != "" {
 		var h api.ServerInterface = struct {
 			*SciCatHandler
 			*S3Handler

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"fmt"
 	"os"
 	"strings"
 )
@@ -10,25 +9,20 @@ type Config struct {
 	SciCatURL          string
 	JobManagerUsername string
 	JobManagerPassword string
+	S3Bucket           string
 }
 
 // Load reads environment variables and validates them.
 func Load() (*Config, error) {
-	scicatURL := os.Getenv("SCICAT_URL")
-	if scicatURL == "" {
-		return nil, fmt.Errorf("SCICAT_URL environment variable is required")
-	}
-
-	password := os.Getenv("JOB_MANAGER_PASSWORD")
-
 	username := os.Getenv("JOB_MANAGER_USERNAME")
 	if username == "" {
 		username = "jobManager"
 	}
 
 	return &Config{
-		SciCatURL:          strings.TrimRight(scicatURL, "/"),
+		SciCatURL:          strings.TrimRight(os.Getenv("SCICAT_URL"), "/"),
 		JobManagerUsername: username,
-		JobManagerPassword: password,
+		JobManagerPassword: os.Getenv("JOB_MANAGER_PASSWORD"),
+		S3Bucket:           os.Getenv("S3_BUCKET"),
 	}, nil
 }

--- a/internal/s3/s3_handler.go
+++ b/internal/s3/s3_handler.go
@@ -1,32 +1,34 @@
 package s3
 
 import (
-	"net/http"
-
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"log"
+	"net/http"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
-
 	"github.com/gin-gonic/gin"
 	"github.com/paulscherrerinstitute/scicat-s3-broker/internal/api"
+	appconfig "github.com/paulscherrerinstitute/scicat-s3-broker/internal/config"
 )
 
-type Handler struct{}
+type Handler struct {
+	cfg *appconfig.Config
+}
 
-func NewHandler() *Handler {
-	return &Handler{}
+func NewHandler(cfg *appconfig.Config) *Handler {
+	return &Handler{cfg: cfg}
 }
 
 // GetDatasetsS3Creds handles the /datasets/s3-creds endpoint
-func (*Handler) GetDatasetsS3Creds(c *gin.Context, params api.GetDatasetsS3CredsParams) {
-	// Get the dataset parameter from query string
+func (h *Handler) GetDatasetsS3Creds(c *gin.Context, params api.GetDatasetsS3CredsParams) {
 	dataset := params.Pid
 
-	// Get the Authorization header
 	authHeader := c.GetHeader("Authorization")
 	if authHeader == "" {
 		c.JSON(http.StatusUnauthorized, gin.H{
@@ -44,14 +46,14 @@ func (*Handler) GetDatasetsS3Creds(c *gin.Context, params api.GetDatasetsS3Creds
 		return
 	}
 
-	cfg, err := config.LoadDefaultConfig(context.TODO(),
-		config.WithSharedCredentialsFiles(
+	cfg, err := awsconfig.LoadDefaultConfig(context.TODO(),
+		awsconfig.WithSharedCredentialsFiles(
 			[]string{"env/credentials"},
 		),
-		config.WithSharedConfigFiles(
+		awsconfig.WithSharedConfigFiles(
 			[]string{"env/config"},
 		),
-		config.WithSharedConfigProfile("ceph"))
+		awsconfig.WithSharedConfigProfile("ceph"))
 	if err != nil {
 		log.Printf("Failed to load AWS config: %v", err)
 		c.JSON(http.StatusInternalServerError, gin.H{
@@ -120,4 +122,86 @@ func (*Handler) GetDatasetsS3Creds(c *gin.Context, params api.GetDatasetsS3Creds
 	}
 
 	c.JSON(http.StatusOK, response)
+}
+
+type expiryTier struct {
+	duration time.Duration
+	prefix   string
+}
+
+var expiryTiers = map[string]expiryTier{
+	"1d": {24 * time.Hour, "d1"},
+	"3d": {72 * time.Hour, "d3"},
+	"7d": {168 * time.Hour, "d7"},
+}
+
+// CreateUploadSession generates presigned PUT and GET URLs for a new random object path.
+// Optional query param: expiry=1d|3d|7d (default: 1d)
+func (h *Handler) CreateUploadSession(c *gin.Context) {
+	filename := c.Query("filename")
+	if filename == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "filename query parameter is required"})
+		return
+	}
+	if h.cfg.S3Bucket == "" {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "S3_BUCKET is not configured"})
+		return
+	}
+
+	expiryKey := c.DefaultQuery("expiry", "1d")
+	tier, ok := expiryTiers[expiryKey]
+	if !ok {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "expiry must be one of: 1d, 3d, 7d"})
+		return
+	}
+	duration := tier.duration
+
+	cfg, err := awsconfig.LoadDefaultConfig(context.TODO(),
+		awsconfig.WithSharedCredentialsFiles([]string{"env/credentials"}),
+		awsconfig.WithSharedConfigFiles([]string{"env/config"}),
+		awsconfig.WithSharedConfigProfile("ceph"))
+	if err != nil {
+		log.Printf("Failed to load AWS config: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal server error"})
+		return
+	}
+
+	objectKey := tier.prefix + "/" + randomID() + "/" + filename
+
+	presigner := s3.NewPresignClient(s3.NewFromConfig(cfg, func(o *s3.Options) {
+		o.UsePathStyle = true
+	}))
+
+	putReq, err := presigner.PresignPutObject(context.TODO(), &s3.PutObjectInput{
+		Bucket: aws.String(h.cfg.S3Bucket),
+		Key:    aws.String(objectKey),
+	}, s3.WithPresignExpires(duration))
+	if err != nil {
+		log.Printf("Failed to presign PUT: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal server error"})
+		return
+	}
+
+	getReq, err := presigner.PresignGetObject(context.TODO(), &s3.GetObjectInput{
+		Bucket: aws.String(h.cfg.S3Bucket),
+		Key:    aws.String(objectKey),
+	}, s3.WithPresignExpires(duration))
+	if err != nil {
+		log.Printf("Failed to presign GET: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal server error"})
+		return
+	}
+
+	c.PureJSON(http.StatusOK, gin.H{
+		"upload_url":   putReq.URL,
+		"download_url": getReq.URL,
+		"path":         objectKey,
+		"expires":      time.Now().Add(duration),
+	})
+}
+
+func randomID() string {
+	b := make([]byte, 16)
+	_, _ = rand.Read(b)
+	return hex.EncodeToString(b)
 }


### PR DESCRIPTION
Adds a new endpoint that returns a pair of presigned PUT and GET URLs for a fresh random object path under a tiered prefix (d1/, d3/, d7/), intended to be paired with matching S3 lifecycle rules for automatic cleanup.

  - New env var `S3_BUCKET` configures the target bucket
  - Optional `?expiry=1d|3d|7d` query param (default `1d`) controls both URL validity and the storage prefix
  - `SCICAT_URL` is now optional; SciCat-backed endpoints register a not-implemented handler when SciCat is not configured
  - Use path-style addressing and PureJSON to avoid HTML-escaping & in presigned URL query strings