### PR TITLE
feat: refactor policy building and authorization to separate components and add authorization against SciCat

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,14 +31,15 @@ The following environement variables are available for configuration:
 
 | env var              | required | default    | description                                                 | example                            |
 | -------------------- | -------- | ---------- | ----------------------------------------------------------- | ---------------------------------- |
-| SCICAT_URL           | yes      |            | SciCat backend base url                                     | https://scicat.development.psi.ch/ |
+| SCICAT_URL           | no\*    |            | SciCat backend base url                                     | https://scicat.development.psi.ch/ |
 | JOB_MANAGER_USERNAME | no       | jobManager | credentials for functional account to query /jobs in SciCat |                                    |
 | JOB_MANAGER_PASSWORD | no\*     | ""         |                                                             |                                    |
 | PORT                 | no       | 8080       | The port to serve from. This is a Gin configuration         |                                    |
 | GIN_MODE             | no       | debug      | Set to `release` for production                             |                                    |
 
-\* JOB_MANAGER_PASSWORD is _required_ for the `/datasets/urls` endpoint. If not set, the server returns `HTTP 501 Not Implemented`.
-It is not required for the `/datasets/s3-creds` endpoint.
+\* `SCICAT_URL` and `JOB_MANAGER_PASSWORD` are both _required_ for the `/datasets/urls` and `/publisheddata/urls` endpoints. If either is not set, the server returns `HTTP 501 Not Implemented`.
+
+If `SCICAT_URL` is set, `/datasets/s3-creds` validates the bearer token against SciCat via [SciCatAuthorizer](./internal/auth/scicat_authorizer.go). If unset, it uses [NoOpAuthorizer](./internal/auth/noop_authorizer.go) (no token validation).
 
 #### AWS Config
 The AWS shared config and credentials files are in [env/](./env) directory. Copy `credentials.example` to `credentials` and replace with your secret / access key.
@@ -56,6 +57,8 @@ go run ./cmd/server
 The server will start on port `8080` by default, or `${PORT}` env variable if specified.
 
 ##### Example requests
+
+Visit the OpenAPI explorer at http://localhost:8080/docs
 
 ###### /datasets/s3-creds
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/paulscherrerinstitute/scicat-s3-broker/internal/api"
+	"github.com/paulscherrerinstitute/scicat-s3-broker/internal/auth"
 	"github.com/paulscherrerinstitute/scicat-s3-broker/internal/config"
 	"github.com/paulscherrerinstitute/scicat-s3-broker/internal/s3"
 	"github.com/paulscherrerinstitute/scicat-s3-broker/internal/scicat"
@@ -18,8 +19,6 @@ func main() {
 		log.Fatalf("Failed to load configuration: %v", err)
 	}
 
-	s3Handler := s3.NewHandler()
-
 	openapi.RegisterSpecRoutes(router)
 
 	router.GET("/health", func(c *gin.Context) {
@@ -27,11 +26,25 @@ func main() {
 			"status": "healthy",
 		})
 	})
+	opts := api.GinServerOptions{
+		ErrorHandler: func(c *gin.Context, err error, statusCode int) {
+			c.JSON(statusCode, gin.H{"error": err.Error()})
+		},
+	}
+
 	type SciCatHandler = scicat.Handler
 	type SciCatNotImplHandler = scicat.NotImplHandler
 	type S3Handler = s3.Handler
 
-	if cfg.JobManagerPassword != "" {
+	var authorizer auth.Authorizer
+	if cfg.SciCatURL != "" {
+		authorizer = auth.NewSciCatAuthorizer(cfg.SciCatURL)
+	} else {
+		authorizer = auth.NewNoOpAuthorizer()
+	}
+	s3Handler := s3.NewHandler(authorizer)
+
+	if cfg.SciCatURL != "" && cfg.JobManagerPassword != "" {
 		var h api.ServerInterface = struct {
 			*SciCatHandler
 			*S3Handler
@@ -39,7 +52,7 @@ func main() {
 			scicat.NewHandler(cfg),
 			s3Handler,
 		}
-		api.RegisterHandlers(router, h)
+		api.RegisterHandlersWithOptions(router, h, opts)
 	} else {
 		var h api.ServerInterface = struct {
 			*SciCatNotImplHandler
@@ -48,7 +61,7 @@ func main() {
 			scicat.NewNoImplHandler(),
 			s3Handler,
 		}
-		api.RegisterHandlers(router, h)
+		api.RegisterHandlersWithOptions(router, h, opts)
 	}
 
 	if err := router.Run(); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.26.0
 require (
 	github.com/aws/aws-sdk-go-v2 v1.41.7
 	github.com/aws/aws-sdk-go-v2/config v1.32.17
-	github.com/aws/aws-sdk-go-v2/service/s3 v1.101.0
 	github.com/aws/aws-sdk-go-v2/service/sts v1.42.1
 	github.com/gin-gonic/gin v1.12.0
 	github.com/google/go-cmp v0.7.0
@@ -20,16 +19,13 @@ require (
 	github.com/PuerkitoBio/purell v1.1.1 // indirect
 	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
 	github.com/apapsch/go-jsonmerge/v2 v2.0.0 // indirect
-	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.10 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.16 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.23 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.23 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.23 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.24 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.9 // indirect
-	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.15 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.23 // indirect
-	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.23 // indirect
 	github.com/aws/aws-sdk-go-v2/service/signin v1.0.11 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.17 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.21 // indirect

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,6 @@ github.com/apapsch/go-jsonmerge/v2 v2.0.0 h1:axGnT1gRIfimI7gJifB699GoE/oq+F2MU7D
 github.com/apapsch/go-jsonmerge/v2 v2.0.0/go.mod h1:lvDnEdqiQrp0O42VQGgmlKpxL1AP2+08jFMw88y4klk=
 github.com/aws/aws-sdk-go-v2 v1.41.7 h1:DWpAJt66FmnnaRIOT/8ASTucrvuDPZASqhhLey6tLY8=
 github.com/aws/aws-sdk-go-v2 v1.41.7/go.mod h1:4LAfZOPHNVNQEckOACQx60Y8pSRjIkNZQz1w92xpMJc=
-github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.10 h1:gx1AwW1Iyk9Z9dD9F4akX5gnN3QZwUB20GGKH/I+Rho=
-github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.10/go.mod h1:qqY157uZoqm5OXq/amuaBJyC9hgBCBQnsaWnPe905GY=
 github.com/aws/aws-sdk-go-v2/config v1.32.17 h1:FpL4/758/diKwqbytU0prpuiu60fgXKUWCpDJtApclU=
 github.com/aws/aws-sdk-go-v2/config v1.32.17/go.mod h1:OXqUMzgXytfoF9JaKkhrOYsyh72t9G+MJH8mMRaexOE=
 github.com/aws/aws-sdk-go-v2/credentials v1.19.16 h1:r3RJBuU7X9ibt8RHbMjWE6y60QbKBiII6wSrXnapxSU=
@@ -25,14 +23,8 @@ github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.24 h1:OQqn11BtaYv1WLUowvcA30MpzIu
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.24/go.mod h1:X5ZJyfwVrWA96GzPmUCWFQaEARPR7gCrpq2E92PJwAE=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.9 h1:FLudkZLt5ci0ozzgkVo8BJGwvqNaZbTWb3UcucAateA=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.9/go.mod h1:w7wZ/s9qK7c8g4al+UyoF1Sp/Z45UwMGcqIzLWVQHWk=
-github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.15 h1:ieLCO1JxUWuxTZ1cRd0GAaeX7O6cIxnwk7tc1LsQhC4=
-github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.15/go.mod h1:e3IzZvQ3kAWNykvE0Tr0RDZCMFInMvhku3qNpcIQXhM=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.23 h1:pbrxO/kuIwgEsOPLkaHu0O+m4fNgLU8B3vxQ+72jTPw=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.23/go.mod h1:/CMNUqoj46HpS3MNRDEDIwcgEnrtZlKRaHNaHxIFpNA=
-github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.23 h1:03xatSQO4+AM1lTAbnRg5OK528EUg744nW7F73U8DKw=
-github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.23/go.mod h1:M8l3mwgx5ToK7wot2sBBce/ojzgnPzZXUV445gTSyE8=
-github.com/aws/aws-sdk-go-v2/service/s3 v1.101.0 h1:etqBTKY581iwLL/H/S2sVgk3C9lAsTJFeXWFDsDcWOU=
-github.com/aws/aws-sdk-go-v2/service/s3 v1.101.0/go.mod h1:L2dcoOgS2VSgbPLvpak2NyUPsO1TBN7M45Z4H7DlRc4=
 github.com/aws/aws-sdk-go-v2/service/signin v1.0.11 h1:TdJ+HdzOBhU8+iVAOGUTU63VXopcumCOF1paFulHWZc=
 github.com/aws/aws-sdk-go-v2/service/signin v1.0.11/go.mod h1:R82ZRExE/nheo0N+T8zHPcLRTcH8MGsnR3BiVGX0TwI=
 github.com/aws/aws-sdk-go-v2/service/sso v1.30.17 h1:7byT8HUWrgoRp6sXjxtZwgOKfhss5fW6SkLBtqzgRoE=

--- a/internal/api/api.gen.go
+++ b/internal/api/api.gen.go
@@ -16,6 +16,24 @@ const (
 	BearerAuthScopes bearerAuthContextKey = "BearerAuth.Scopes"
 )
 
+// Defines values for GetDatasetsS3CredsParamsOperation.
+const (
+	Read  GetDatasetsS3CredsParamsOperation = "read"
+	Write GetDatasetsS3CredsParamsOperation = "write"
+)
+
+// Valid indicates whether the value is a known member of the GetDatasetsS3CredsParamsOperation enum.
+func (e GetDatasetsS3CredsParamsOperation) Valid() bool {
+	switch e {
+	case Read:
+		return true
+	case Write:
+		return true
+	default:
+		return false
+	}
+}
+
 // DatasetsUrlResponse defines model for DatasetsUrlResponse.
 type DatasetsUrlResponse struct {
 	// Expires The earliest expiration of all urls for this dataset
@@ -67,7 +85,13 @@ type bearerAuthContextKey string
 type GetDatasetsS3CredsParams struct {
 	// Pid The unique identifier of the dataset
 	Pid string `form:"pid" json:"pid"`
+
+	// Operation The operation to request credentials for
+	Operation *GetDatasetsS3CredsParamsOperation `form:"operation,omitempty" json:"operation,omitempty"`
 }
+
+// GetDatasetsS3CredsParamsOperation defines parameters for GetDatasetsS3Creds.
+type GetDatasetsS3CredsParamsOperation string
 
 // GetDatasetsUrlsParams defines parameters for GetDatasetsUrls.
 type GetDatasetsUrlsParams struct {
@@ -119,6 +143,14 @@ func (siw *ServerInterfaceWrapper) GetDatasetsS3Creds(c *gin.Context) {
 	err = runtime.BindQueryParameterWithOptions("form", true, true, "pid", c.Request.URL.Query(), &params.Pid, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
 	if err != nil {
 		siw.ErrorHandler(c, fmt.Errorf("Invalid format for parameter pid: %w", err), http.StatusBadRequest)
+		return
+	}
+
+	// ------------- Optional query parameter "operation" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "operation", c.Request.URL.Query(), &params.Operation, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandler(c, fmt.Errorf("Invalid format for parameter operation: %w", err), http.StatusBadRequest)
 		return
 	}
 

--- a/internal/auth/authorizer.go
+++ b/internal/auth/authorizer.go
@@ -1,0 +1,14 @@
+package auth
+
+import "github.com/gin-gonic/gin"
+
+type Operation int
+
+const (
+	OperationRead Operation = iota
+	OperationWrite
+)
+
+type Authorizer interface {
+	Authorize(c *gin.Context, pid string, operation Operation) error
+}

--- a/internal/auth/noop_authorizer.go
+++ b/internal/auth/noop_authorizer.go
@@ -1,0 +1,13 @@
+package auth
+
+import "github.com/gin-gonic/gin"
+
+type NoOpAuthorizer struct{}
+
+func NewNoOpAuthorizer() *NoOpAuthorizer {
+	return &NoOpAuthorizer{}
+}
+
+func (*NoOpAuthorizer) Authorize(_ *gin.Context, _ string, _ Operation) error {
+	return nil
+}

--- a/internal/auth/scicat_authorizer.go
+++ b/internal/auth/scicat_authorizer.go
@@ -1,0 +1,62 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/gin-gonic/gin"
+)
+
+type SciCatAuthorizer struct {
+	scicatURL string
+}
+
+func NewSciCatAuthorizer(scicatURL string) *SciCatAuthorizer {
+	return &SciCatAuthorizer{scicatURL: scicatURL}
+}
+
+func (a *SciCatAuthorizer) Authorize(c *gin.Context, pid string, operation Operation) error {
+	if operation == OperationWrite {
+		return fmt.Errorf("write operation not implemented yet")
+	}
+
+	authHeader := c.GetHeader("Authorization")
+	if authHeader == "" {
+		return fmt.Errorf("Authorization header is required")
+	}
+	if len(authHeader) < 7 || authHeader[:7] != "Bearer " {
+		return fmt.Errorf("invalid authorization header format, expected 'Bearer <token>'")
+	}
+	token := authHeader[7:]
+
+	return a.scicatGetDataset(c.Request.Context(), pid, token)
+}
+
+func (a *SciCatAuthorizer) scicatGetDataset(ctx context.Context, pid string, token string) error {
+	u, err := url.Parse(fmt.Sprintf("%s/api/v3/datasets/%s", a.scicatURL, url.PathEscape(pid)))
+	if err != nil {
+		return fmt.Errorf("failed to build dataset URL: %w", err)
+	}
+	q := u.Query()
+	q.Set("filter", `{"fields":["_id"]}`)
+	u.RawQuery = q.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to contact SciCat: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("SciCat returned %d for dataset %q", resp.StatusCode, pid)
+	}
+	return nil
+}

--- a/internal/auth/scicat_authorizer_test.go
+++ b/internal/auth/scicat_authorizer_test.go
@@ -1,0 +1,106 @@
+package auth
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestSciCatAuthorizer_Authorize(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	pid := "test-pid-123"
+
+	tests := []struct {
+		name           string
+		authHeader     string
+		operation      Operation
+		mockStatusCode int
+		wantErr        bool
+		wantHTTPCall   bool
+	}{
+		{
+			name:         "temporary/to-do: not implemented Operation write",
+			authHeader:   "Bearer valid-token",
+			operation:    OperationWrite,
+			wantErr:      true,
+			wantHTTPCall: false,
+		},
+		{
+			name:         "missing Authorization header",
+			authHeader:   "",
+			operation:    OperationRead,
+			wantErr:      true,
+			wantHTTPCall: false,
+		},
+		{
+			name:         "malformed Authorization header",
+			authHeader:   "Basic dGVzdA==",
+			operation:    OperationRead,
+			wantErr:      true,
+			wantHTTPCall: false,
+		},
+		{
+			name:           "SciCat returns 200",
+			authHeader:     "Bearer valid-token",
+			operation:      OperationRead,
+			mockStatusCode: http.StatusOK,
+			wantErr:        false,
+			wantHTTPCall:   true,
+		},
+		{
+			name:           "SciCat returns non-200",
+			authHeader:     "Bearer valid-token",
+			operation:      OperationRead,
+			mockStatusCode: http.StatusForbidden,
+			wantErr:        true,
+			wantHTTPCall:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var capturedReq *http.Request
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				capturedReq = r
+				w.WriteHeader(tt.mockStatusCode)
+			}))
+			defer server.Close()
+
+			authorizer := NewSciCatAuthorizer(server.URL)
+
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			if tt.authHeader != "" {
+				req.Header.Set("Authorization", tt.authHeader)
+			}
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			c.Request = req
+
+			err := authorizer.Authorize(c, pid, tt.operation)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Authorize() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if tt.wantHTTPCall {
+				if capturedReq == nil {
+					t.Fatal("expected HTTP call to SciCat, none was made")
+				}
+				if capturedReq.URL.Path != "/api/v3/datasets/"+pid {
+					t.Errorf("request path = %q, want %q", capturedReq.URL.Path, "/api/v3/datasets/"+pid)
+				}
+				if got := capturedReq.URL.Query().Get("filter"); got != `{"fields":["_id"]}` {
+					t.Errorf("filter param = %q, want %q", got, `{"fields":["_id"]}`)
+				}
+				if got := capturedReq.Header.Get("Authorization"); got != tt.authHeader {
+					t.Errorf("Authorization header = %q, want %q", got, tt.authHeader)
+				}
+			} else if capturedReq != nil {
+				t.Error("expected no HTTP call to SciCat, but one was made")
+			}
+		})
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"fmt"
 	"os"
 	"strings"
 )
@@ -15,9 +14,6 @@ type Config struct {
 // Load reads environment variables and validates them.
 func Load() (*Config, error) {
 	scicatURL := os.Getenv("SCICAT_URL")
-	if scicatURL == "" {
-		return nil, fmt.Errorf("SCICAT_URL environment variable is required")
-	}
 
 	password := os.Getenv("JOB_MANAGER_PASSWORD")
 

--- a/internal/s3/policy.go
+++ b/internal/s3/policy.go
@@ -1,0 +1,64 @@
+package s3
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/paulscherrerinstitute/scicat-s3-broker/internal/auth"
+)
+
+type policyDocument struct {
+	Version   string            `json:"Version"`
+	Statement []policyStatement `json:"Statement"`
+}
+
+type policyStatement struct {
+	Effect    string           `json:"Effect"`
+	Action    any              `json:"Action"`
+	Resource  any              `json:"Resource"`
+	Condition *policyCondition `json:"Condition,omitempty"`
+}
+
+type policyCondition struct {
+	StringLike map[string][]string `json:"StringLike,omitempty"`
+}
+
+// buildScopedPolicy returns an IAM policy JSON string that restricts access to
+// the given dataset and operation
+func buildScopedPolicy(dataset string, operation auth.Operation) (string, error) {
+	datasetArn := "arn:aws:s3:::datasets/" + dataset
+
+	var objectActions any
+	if operation == auth.OperationWrite {
+		objectActions = "s3:*"
+	} else {
+		objectActions = []string{"s3:Get*", "s3:List*"}
+	}
+
+	doc := policyDocument{
+		Version: "2012-10-17",
+		Statement: []policyStatement{
+			{
+				Effect:   "Allow",
+				Action:   objectActions,
+				Resource: []string{datasetArn, datasetArn + "/*"},
+			},
+			{
+				Effect:   "Allow",
+				Action:   "s3:ListBucket",
+				Resource: "arn:aws:s3:::datasets",
+				Condition: &policyCondition{
+					StringLike: map[string][]string{
+						"s3:prefix": {dataset + "/"},
+					},
+				},
+			},
+		},
+	}
+
+	b, err := json.Marshal(doc)
+	if err != nil {
+		return "", fmt.Errorf("error marshalling policy document: %w", err)
+	}
+	return string(b), nil
+}

--- a/internal/s3/policy_test.go
+++ b/internal/s3/policy_test.go
@@ -1,0 +1,66 @@
+package s3
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/paulscherrerinstitute/scicat-s3-broker/internal/auth"
+)
+
+func TestBuildScopedPolicy(t *testing.T) {
+	dataset := "my-dataset"
+
+	tests := []struct {
+		name        string
+		operation   auth.Operation
+		wantActions any
+	}{
+		{
+			name:        "read grants restricted actions",
+			operation:   auth.OperationRead,
+			wantActions: []string{"s3:Get*", "s3:List*"},
+		},
+		{
+			name:        "write grants s3:*",
+			operation:   auth.OperationWrite,
+			wantActions: "s3:*",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := buildScopedPolicy(dataset, tt.operation)
+			if err != nil {
+				t.Fatalf("buildScopedPolicy() error = %v", err)
+			}
+
+			var doc policyDocument
+			if err := json.Unmarshal([]byte(got), &doc); err != nil {
+				t.Fatalf("output is not valid JSON: %v", err)
+			}
+
+			datasetARN := "arn:aws:s3:::datasets/" + dataset
+			stmt, ok := findStatementByResource(doc, datasetARN)
+			if !ok {
+				t.Fatalf("no statement found with resource %q", datasetARN)
+			}
+
+			gotActions, _ := json.Marshal(stmt.Action)
+			wantActions, _ := json.Marshal(tt.wantActions)
+			if string(gotActions) != string(wantActions) {
+				t.Errorf("Action = %s, want %s", gotActions, wantActions)
+			}
+		})
+	}
+}
+
+func findStatementByResource(doc policyDocument, arn string) (policyStatement, bool) {
+	for _, stmt := range doc.Statement {
+		resourcesJSON, _ := json.Marshal(stmt.Resource)
+		if strings.Contains(string(resourcesJSON), arn) {
+			return stmt, true
+		}
+	}
+	return policyStatement{}, false
+}

--- a/internal/s3/s3_handler.go
+++ b/internal/s3/s3_handler.go
@@ -1,50 +1,43 @@
 package s3
 
 import (
-	"net/http"
-
-	"context"
+	"fmt"
 	"log"
+	"net/http"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
-
 	"github.com/gin-gonic/gin"
 	"github.com/paulscherrerinstitute/scicat-s3-broker/internal/api"
+	"github.com/paulscherrerinstitute/scicat-s3-broker/internal/auth"
 )
 
-type Handler struct{}
+type Handler struct {
+	authorizer auth.Authorizer
+}
 
-func NewHandler() *Handler {
-	return &Handler{}
+func NewHandler(authorizer auth.Authorizer) *Handler {
+	return &Handler{authorizer: authorizer}
 }
 
 // GetDatasetsS3Creds handles the /datasets/s3-creds endpoint
-func (*Handler) GetDatasetsS3Creds(c *gin.Context, params api.GetDatasetsS3CredsParams) {
-	// Get the dataset parameter from query string
+func (h *Handler) GetDatasetsS3Creds(c *gin.Context, params api.GetDatasetsS3CredsParams) {
 	dataset := params.Pid
 
-	// Get the Authorization header
-	authHeader := c.GetHeader("Authorization")
-	if authHeader == "" {
-		c.JSON(http.StatusUnauthorized, gin.H{
-			"error": "Authorization header is required",
-		})
+	operation, err := parseOperation(params.Operation)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
 
-	// TODO: In a real implementation, validate the SciCat token here
-	// For now, we'll just check if it starts with "Bearer "
-	if len(authHeader) < 7 || authHeader[:7] != "Bearer " {
-		c.JSON(http.StatusUnauthorized, gin.H{
-			"error": "Invalid authorization header format. Expected 'Bearer <token>'",
-		})
+	if err := h.authorizer.Authorize(c, dataset, operation); err != nil {
+		log.Println("authorization failed", err)
+		c.JSON(http.StatusForbidden, gin.H{"error": "Forbidden"})
 		return
 	}
 
-	cfg, err := config.LoadDefaultConfig(context.TODO(),
+	cfg, err := config.LoadDefaultConfig(c.Request.Context(),
 		config.WithSharedCredentialsFiles(
 			[]string{"env/credentials"},
 		),
@@ -60,46 +53,15 @@ func (*Handler) GetDatasetsS3Creds(c *gin.Context, params api.GetDatasetsS3Creds
 		return
 	}
 
-	s3Client := s3.NewFromConfig(cfg)
-	out, err := s3Client.ListBuckets(context.TODO(), &s3.ListBucketsInput{})
+	policy, err := buildScopedPolicy(dataset, operation)
 	if err != nil {
-		log.Printf("Failed to list S3 buckets: %v", err)
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"error": "Internal server error",
-		})
+		log.Printf("Failed to build policy: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal server error"})
 		return
-	}
-	for _, bucket := range out.Buckets {
-		log.Printf("Bucket: %s, Created on: %s", *bucket.Name, bucket.CreationDate)
 	}
 
 	stsClient := sts.NewFromConfig(cfg)
-	policy := `{
-		"Version": "2012-10-17",
-		"Statement": [
-			{
-				"Effect": "Allow",
-				"Action": "s3:*",
-				"Resource": [
-					"arn:aws:s3:::datasets/` + dataset + `",
-					"arn:aws:s3:::datasets/` + dataset + `/*"
-				]
-			},
-			{
-				"Effect": "Allow",
-				"Action": "s3:ListBucket",
-				"Resource": "arn:aws:s3:::datasets",
-				"Condition": {
-					"StringLike": {
-						"s3:prefix": [
-							"` + dataset + `/"
-						]
-					}
-				}
-			}
-		]
-	}`
-	stsOut, err := stsClient.AssumeRole(context.TODO(), &sts.AssumeRoleInput{
+	stsOut, err := stsClient.AssumeRole(c.Request.Context(), &sts.AssumeRoleInput{
 		RoleArn:         aws.String("arn:aws:iam:::role/PsiLimitedAccessRole"),
 		RoleSessionName: aws.String("scicat-session"),
 		Policy:          aws.String(policy),
@@ -120,4 +82,18 @@ func (*Handler) GetDatasetsS3Creds(c *gin.Context, params api.GetDatasetsS3Creds
 	}
 
 	c.JSON(http.StatusOK, response)
+}
+
+func parseOperation(op *api.GetDatasetsS3CredsParamsOperation) (auth.Operation, error) {
+	if op == nil {
+		return auth.OperationRead, nil
+	}
+	switch *op {
+	case api.Read:
+		return auth.OperationRead, nil
+	case api.Write:
+		return auth.OperationWrite, nil
+	default:
+		return 0, fmt.Errorf("invalid operation %q, expected read or write", *op)
+	}
 }

--- a/internal/s3/s3_handler.go
+++ b/internal/s3/s3_handler.go
@@ -1,6 +1,7 @@
 package s3
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"net/http"
@@ -15,10 +16,23 @@ import (
 
 type Handler struct {
 	authorizer auth.Authorizer
+	stsClient  *sts.Client
 }
 
 func NewHandler(authorizer auth.Authorizer) *Handler {
-	return &Handler{authorizer: authorizer}
+	cfg, err := config.LoadDefaultConfig(context.TODO(),
+		config.WithSharedCredentialsFiles(
+			[]string{"env/credentials"},
+		),
+		config.WithSharedConfigFiles(
+			[]string{"env/config"},
+		),
+		config.WithSharedConfigProfile("ceph"))
+	if err != nil {
+		log.Fatalf("Failed to load AWS config: %v", err)
+	}
+
+	return &Handler{authorizer: authorizer, stsClient: sts.NewFromConfig(cfg)}
 }
 
 // GetDatasetsS3Creds handles the /datasets/s3-creds endpoint
@@ -37,22 +51,6 @@ func (h *Handler) GetDatasetsS3Creds(c *gin.Context, params api.GetDatasetsS3Cre
 		return
 	}
 
-	cfg, err := config.LoadDefaultConfig(c.Request.Context(),
-		config.WithSharedCredentialsFiles(
-			[]string{"env/credentials"},
-		),
-		config.WithSharedConfigFiles(
-			[]string{"env/config"},
-		),
-		config.WithSharedConfigProfile("ceph"))
-	if err != nil {
-		log.Printf("Failed to load AWS config: %v", err)
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"error": "Internal server error",
-		})
-		return
-	}
-
 	policy, err := buildScopedPolicy(dataset, operation)
 	if err != nil {
 		log.Printf("Failed to build policy: %v", err)
@@ -60,8 +58,7 @@ func (h *Handler) GetDatasetsS3Creds(c *gin.Context, params api.GetDatasetsS3Cre
 		return
 	}
 
-	stsClient := sts.NewFromConfig(cfg)
-	stsOut, err := stsClient.AssumeRole(c.Request.Context(), &sts.AssumeRoleInput{
+	stsOut, err := h.stsClient.AssumeRole(c.Request.Context(), &sts.AssumeRoleInput{
 		RoleArn:         aws.String("arn:aws:iam:::role/PsiLimitedAccessRole"),
 		RoleSessionName: aws.String("scicat-session"),
 		Policy:          aws.String(policy),

--- a/internal/s3/s3_handler_test.go
+++ b/internal/s3/s3_handler_test.go
@@ -44,7 +44,7 @@ func TestS3Handler_GetDatasetsS3Creds(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			handler := NewHandler(tt.authorizer)
+			handler := &Handler{authorizer: tt.authorizer}
 
 			req := httptest.NewRequest(http.MethodGet, "/datasets/s3-creds", nil)
 			w := httptest.NewRecorder()

--- a/internal/s3/s3_handler_test.go
+++ b/internal/s3/s3_handler_test.go
@@ -1,0 +1,61 @@
+package s3
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/paulscherrerinstitute/scicat-s3-broker/internal/api"
+	"github.com/paulscherrerinstitute/scicat-s3-broker/internal/auth"
+)
+
+type mockAuthorizer struct{ err error }
+
+func (m *mockAuthorizer) Authorize(_ *gin.Context, _ string, _ auth.Operation) error {
+	return m.err
+}
+
+func TestS3Handler_GetDatasetsS3Creds(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	invalidOp := api.GetDatasetsS3CredsParamsOperation("delete")
+
+	tests := []struct {
+		name       string
+		params     api.GetDatasetsS3CredsParams
+		authorizer auth.Authorizer
+		wantStatus int
+	}{
+		{
+			name:       "invalid operation returns 400",
+			params:     api.GetDatasetsS3CredsParams{Pid: "some-dataset", Operation: &invalidOp},
+			authorizer: &mockAuthorizer{},
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "authorizer error returns 403",
+			params:     api.GetDatasetsS3CredsParams{Pid: "some-dataset"},
+			authorizer: &mockAuthorizer{err: fmt.Errorf("internal auth error")},
+			wantStatus: http.StatusForbidden,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler := NewHandler(tt.authorizer)
+
+			req := httptest.NewRequest(http.MethodGet, "/datasets/s3-creds", nil)
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			c.Request = req
+
+			handler.GetDatasetsS3Creds(c, tt.params)
+
+			if w.Code != tt.wantStatus {
+				t.Errorf("status = %d, want %d", w.Code, tt.wantStatus)
+			}
+		})
+	}
+}

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -97,6 +97,14 @@ paths:
           schema:
             type: string
           description: The unique identifier of the dataset
+        - in: query
+          name: operation
+          required: false
+          schema:
+            type: string
+            enum: [read, write]
+            default: read
+          description: The operation to request credentials for
       responses:
         "200":
           description: Temporary S3 credentials for the dataset


### PR DESCRIPTION
### Intro
Before, s3-handler was just a prototype, that built the STS Policy inline and returned a token with full access `s3:*` for the provided dataset (i.e. the path `/datasets/{pid}` in Ceph).

In this PR, we have added an additional parameter `operation = read | write` to the /datasets/s3-creds API ([openapi.yaml](https://github.com/paulscherrerinstitute/scicat-s3-broker/pull/38/changes#diff-5fa520d3bb34f9ae444cdbdf2b9eccff2361eb89a0cd3f4dba1e2e0fa9bba452)). 
For `read`, we check authorization by caling SciCat's `/api/v3/datasets/{pid}`, forwarding the token passed by the user.
`write` is not implemented yet - in a future PR, we will check whether dataset's ownerGroup is included in token's groups to determine write access.

### Changes
1. Refactored authorization logic to an `Authorizer` interface, and provided two implementations: a `SciCatAuthorizer` and a `NoOpAuthorizer`. The `NoOpAuthorizer` can be used by Empa, and they can eventually implement an OIDCAuthorizer.
2. `SCICAT_URL` is now optional - The S3Handler is configured with `NoOpAuthorizer` if it is not set. This is also needed for Empa's use-case where they have no dependency on SciCat and are only intereseted in using the S3 portion of the service: https://github.com/paulscherrerinstitute/scicat-s3-broker/pull/34 
3. Refactored policy building logic to it's own file, and based on operation `read` or `write` appropriate S3 grants are set.

### Testing
Tested with RClone that a read-only mount is possible - this means `s3:Get*` and `s3:List*` permissions on the `dataset/{pid}` resource are sufficient.

With AWS config:
```
[profile ceph_credential_process]
credential_process = ../credential_process --dataset 20.500.11935/fcca7c25-5ded-402c-997a-379be97d0bb0
endpoint_url = https://rgw.cscs.ch
```
and Rclone config:
```
[ceph_cred_process]
type = s3
provider = Ceph
env_auth = true
profile = ceph_credential_process
endpoint = https://rgw.cscs.ch
```
mounting with:
```
SCICAT_TOKEN=<...> rclone -vv mount ceph_cred_process:datasets/20.500.11935/fcca7c25-5ded-402c-997a-379be97d0bb0 /mnt/ceph/
```
we are able to read files and `ls`, but upload fails with 403 as expected.