### PR TITLE
feat: add support for OperationWrite in ScicatAuthorizer

### DIFF
--- a/internal/auth/scicat_authorizer.go
+++ b/internal/auth/scicat_authorizer.go
@@ -2,9 +2,11 @@ package auth
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
+	"slices"
 
 	"github.com/gin-gonic/gin"
 )
@@ -18,10 +20,6 @@ func NewSciCatAuthorizer(scicatURL string) *SciCatAuthorizer {
 }
 
 func (a *SciCatAuthorizer) Authorize(c *gin.Context, pid string, operation Operation) error {
-	if operation == OperationWrite {
-		return fmt.Errorf("write operation not implemented yet")
-	}
-
 	authHeader := c.GetHeader("Authorization")
 	if authHeader == "" {
 		return fmt.Errorf("Authorization header is required")
@@ -31,32 +29,88 @@ func (a *SciCatAuthorizer) Authorize(c *gin.Context, pid string, operation Opera
 	}
 	token := authHeader[7:]
 
-	return a.scicatGetDataset(c.Request.Context(), pid, token)
+	ownerGroup, err := a.scicatGetDataset(c.Request.Context(), pid, token)
+	if err != nil {
+		return err
+	} else if operation == OperationRead {
+		return nil
+	}
+
+	return a.authorizeWrite(c.Request.Context(), ownerGroup, token)
 }
 
-func (a *SciCatAuthorizer) scicatGetDataset(ctx context.Context, pid string, token string) error {
-	u, err := url.Parse(fmt.Sprintf("%s/api/v3/datasets/%s", a.scicatURL, url.PathEscape(pid)))
+func (a *SciCatAuthorizer) authorizeWrite(ctx context.Context, ownerGroup string, token string) error {
+	groups, err := a.scicatWhoami(ctx, token)
 	if err != nil {
-		return fmt.Errorf("failed to build dataset URL: %w", err)
+		return err
 	}
-	q := u.Query()
-	q.Set("filter", `{"fields":["_id"]}`)
-	u.RawQuery = q.Encode()
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if !slices.Contains(groups, ownerGroup) {
+		return fmt.Errorf("user is not a member of the dataset's owner group %q", ownerGroup)
+	}
+	return nil
+}
+
+// scicatWhoami calls /api/v3/auth/whoami and returns user's currentGroups from the response
+func (a *SciCatAuthorizer) scicatWhoami(ctx context.Context, token string) ([]string, error) {
+	u := fmt.Sprintf("%s/api/v3/auth/whoami", a.scicatURL)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
 	if err != nil {
-		return fmt.Errorf("failed to create request: %w", err)
+		return nil, fmt.Errorf("failed to create whoami request: %w", err)
 	}
 	req.Header.Set("Authorization", "Bearer "+token)
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return fmt.Errorf("failed to contact SciCat: %w", err)
+		return nil, fmt.Errorf("failed to contact SciCat whoami: %w", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("SciCat returned %d for dataset %q", resp.StatusCode, pid)
+		return nil, fmt.Errorf("SciCat whoami returned %d", resp.StatusCode)
 	}
-	return nil
+
+	var body struct {
+		CurrentGroups []string `json:"currentGroups"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return nil, fmt.Errorf("failed to decode whoami response: %w", err)
+	}
+	return body.CurrentGroups, nil
+}
+
+// scicatGetDataset checks that the user's token grants read access to the dataset
+// by calling /api/v3/datasets/{pid} and returns the datasets's ownerGroup.
+func (a *SciCatAuthorizer) scicatGetDataset(ctx context.Context, pid string, token string) (string, error) {
+	u, err := url.Parse(fmt.Sprintf("%s/api/v3/datasets/%s", a.scicatURL, url.PathEscape(pid)))
+	if err != nil {
+		return "", fmt.Errorf("failed to build dataset URL: %w", err)
+	}
+	q := u.Query()
+	q.Set("filter", `{"fields":["ownerGroup"]}`)
+	u.RawQuery = q.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to contact SciCat: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("SciCat returned %d for dataset %q", resp.StatusCode, pid)
+	}
+
+	var body struct {
+		OwnerGroup string `json:"ownerGroup"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return "", fmt.Errorf("failed to decode dataset response: %w", err)
+	}
+	return body.OwnerGroup, nil
 }

--- a/internal/auth/scicat_authorizer_test.go
+++ b/internal/auth/scicat_authorizer_test.go
@@ -1,8 +1,10 @@
 package auth
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -12,60 +14,101 @@ func TestSciCatAuthorizer_Authorize(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	pid := "test-pid-123"
+	ownerGroup := "svc-afs"
+
+	datasetBody, _ := json.Marshal(map[string]string{"ownerGroup": ownerGroup})
+	whoamiWithGroup, _ := json.Marshal(map[string]any{"currentGroups": []string{"unx-nogroup", ownerGroup}})
+	whoamiWithoutGroup, _ := json.Marshal(map[string]any{"currentGroups": []string{"unx-nogroup"}})
 
 	tests := []struct {
-		name           string
-		authHeader     string
-		operation      Operation
-		mockStatusCode int
-		wantErr        bool
-		wantHTTPCall   bool
+		name              string
+		authHeader        string
+		operation         Operation
+		mockDatasetStatus int
+		mockDatasetBody   []byte
+		mockWhoamiStatus  int
+		mockWhoamiBody    []byte
+		wantErr           bool
 	}{
 		{
-			name:         "temporary/to-do: not implemented Operation write",
-			authHeader:   "Bearer valid-token",
-			operation:    OperationWrite,
-			wantErr:      true,
-			wantHTTPCall: false,
+			name:       "read: missing Authorization header",
+			authHeader: "",
+			operation:  OperationRead,
+			wantErr:    true,
 		},
 		{
-			name:         "missing Authorization header",
-			authHeader:   "",
-			operation:    OperationRead,
-			wantErr:      true,
-			wantHTTPCall: false,
+			name:       "read: malformed Authorization header",
+			authHeader: "Basic dGVzdA==",
+			operation:  OperationRead,
+			wantErr:    true,
 		},
 		{
-			name:         "malformed Authorization header",
-			authHeader:   "Basic dGVzdA==",
-			operation:    OperationRead,
-			wantErr:      true,
-			wantHTTPCall: false,
+			name:              "read: SciCat returns 200",
+			authHeader:        "Bearer valid-token",
+			operation:         OperationRead,
+			mockDatasetStatus: http.StatusOK,
+			mockDatasetBody:   datasetBody,
+			wantErr:           false,
 		},
 		{
-			name:           "SciCat returns 200",
-			authHeader:     "Bearer valid-token",
-			operation:      OperationRead,
-			mockStatusCode: http.StatusOK,
-			wantErr:        false,
-			wantHTTPCall:   true,
+			name:              "read: SciCat returns 403",
+			authHeader:        "Bearer valid-token",
+			operation:         OperationRead,
+			mockDatasetStatus: http.StatusForbidden,
+			wantErr:           true,
 		},
 		{
-			name:           "SciCat returns non-200",
-			authHeader:     "Bearer valid-token",
-			operation:      OperationRead,
-			mockStatusCode: http.StatusForbidden,
-			wantErr:        true,
-			wantHTTPCall:   true,
+			name:              "write: user in ownerGroup: authorized",
+			authHeader:        "Bearer valid-token",
+			operation:         OperationWrite,
+			mockDatasetStatus: http.StatusOK,
+			mockDatasetBody:   datasetBody,
+			mockWhoamiStatus:  http.StatusOK,
+			mockWhoamiBody:    whoamiWithGroup,
+			wantErr:           false,
+		},
+		{
+			name:              "write: user not in ownerGroup: denied",
+			authHeader:        "Bearer valid-token",
+			operation:         OperationWrite,
+			mockDatasetStatus: http.StatusOK,
+			mockDatasetBody:   datasetBody,
+			mockWhoamiStatus:  http.StatusOK,
+			mockWhoamiBody:    whoamiWithoutGroup,
+			wantErr:           true,
+		},
+		{
+			name:              "write: dataset not accessible: denied before whoami",
+			authHeader:        "Bearer valid-token",
+			operation:         OperationWrite,
+			mockDatasetStatus: http.StatusForbidden,
+			wantErr:           true,
+		},
+		{
+			name:              "write: whoami fails: denied",
+			authHeader:        "Bearer valid-token",
+			operation:         OperationWrite,
+			mockDatasetStatus: http.StatusOK,
+			mockDatasetBody:   datasetBody,
+			mockWhoamiStatus:  http.StatusUnauthorized,
+			wantErr:           true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var capturedReq *http.Request
+			var datasetReq, whoamiReq *http.Request
+
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				capturedReq = r
-				w.WriteHeader(tt.mockStatusCode)
+				if r.URL.Path == "/api/v3/auth/whoami" {
+					whoamiReq = r
+					w.WriteHeader(tt.mockWhoamiStatus)
+					w.Write(tt.mockWhoamiBody)
+				} else if strings.HasPrefix(r.URL.Path, "/api/v3/datasets") {
+					datasetReq = r
+					w.WriteHeader(tt.mockDatasetStatus)
+					w.Write(tt.mockDatasetBody)
+				}
 			}))
 			defer server.Close()
 
@@ -85,21 +128,32 @@ func TestSciCatAuthorizer_Authorize(t *testing.T) {
 				t.Errorf("Authorize() error = %v, wantErr %v", err, tt.wantErr)
 			}
 
-			if tt.wantHTTPCall {
-				if capturedReq == nil {
-					t.Fatal("expected HTTP call to SciCat, none was made")
+			if tt.mockDatasetStatus != 0 {
+				if datasetReq == nil {
+					t.Fatal("expected HTTP call to datasets endpoint, none was made")
 				}
-				if capturedReq.URL.Path != "/api/v3/datasets/"+pid {
-					t.Errorf("request path = %q, want %q", capturedReq.URL.Path, "/api/v3/datasets/"+pid)
+				if datasetReq.URL.Path != "/api/v3/datasets/"+pid {
+					t.Errorf("dataset path = %q, want %q", datasetReq.URL.Path, "/api/v3/datasets/"+pid)
 				}
-				if got := capturedReq.URL.Query().Get("filter"); got != `{"fields":["_id"]}` {
-					t.Errorf("filter param = %q, want %q", got, `{"fields":["_id"]}`)
+				if got := datasetReq.URL.Query().Get("filter"); got != `{"fields":["ownerGroup"]}` {
+					t.Errorf("filter param = %q, want %q", got, `{"fields":["ownerGroup"]}`)
 				}
-				if got := capturedReq.Header.Get("Authorization"); got != tt.authHeader {
-					t.Errorf("Authorization header = %q, want %q", got, tt.authHeader)
+				if got := datasetReq.Header.Get("Authorization"); got != tt.authHeader {
+					t.Errorf("dataset Authorization header = %q, want %q", got, tt.authHeader)
 				}
-			} else if capturedReq != nil {
-				t.Error("expected no HTTP call to SciCat, but one was made")
+			} else if datasetReq != nil {
+				t.Error("expected no HTTP call to datasets endpoint, but one was made")
+			}
+
+			if tt.mockWhoamiStatus != 0 {
+				if whoamiReq == nil {
+					t.Fatal("expected HTTP call to whoami endpoint, none was made")
+				}
+				if got := whoamiReq.Header.Get("Authorization"); got != tt.authHeader {
+					t.Errorf("whoami Authorization header = %q, want %q", got, tt.authHeader)
+				}
+			} else if whoamiReq != nil {
+				t.Error("expected no HTTP call to whoami endpoint, but one was made")
 			}
 		})
 	}


### PR DESCRIPTION
https://github.com/paulscherrerinstitute/scicat-s3-broker/pull/38 implemented SciCatAuthorizer with support for `read` operation in /datasets/s3-creds.

In this PR, we add support for `write` operation. For checking `read` authorization, we were calling `/api/v3/datasets/{pid}` with just `_id` in the filter to see if we get 200. Now we modify the filter to return `ownerGroup` instead of `_id`.

To check `write` authorization, we call `/api/v3/whoami` (forwarding user's scicat token), which returns the user's `currentGroups`, and check whether the `ownerGroup` is included in user's `currentGroups`.

----

adding note from Spencer's comment, so it is included in the commit msg:

Note that this permission check is more restrictive than SciCat. For instance, functional accounts with the ingestor role would not be able to get credentials. I think this is probably fine (or even desirable), and we can add exceptions later if needed.