### PR TITLE
fix: take bucket name from environment rather than hardcoded datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Also included is a simple CLI client that can be used as an AWS CLI credential p
 
 - 🔑 **Credential broker**: returns temporary S3 credentials for a given dataset.
 - 📥 **Download URLs** for public datasets: get presigned URLs for retrieved, public datasets.
-- 🛡 **Authorization via SciCat**: forwards the end-user’s SciCat token for access checks. //TO-DO
+- 🛡 **Authorization via SciCat**: forwards the end-user’s SciCat token for access checks.
 
 ---
 
@@ -36,6 +36,7 @@ The following environement variables are available for configuration:
 | JOB_MANAGER_PASSWORD | no\*     | ""         |                                                             |                                    |
 | PORT                 | no       | 8080       | The port to serve from. This is a Gin configuration         |                                    |
 | GIN_MODE             | no       | debug      | Set to `release` for production                             |                                    |
+| RETRIEVE_BUCKET / UPLOAD_BUCKET | no | datasets | Buckets to generate the read / write scoped policies for | psi-retrieve-dev, psi-upload-dev   |
 
 \* `SCICAT_URL` and `JOB_MANAGER_PASSWORD` are both _required_ for the `/datasets/urls` and `/publisheddata/urls` endpoints. If either is not set, the server returns `HTTP 501 Not Implemented`.
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ The following environement variables are available for configuration:
 | JOB_MANAGER_PASSWORD | no\*     | ""         |                                                             |                                    |
 | PORT                 | no       | 8080       | The port to serve from. This is a Gin configuration         |                                    |
 | GIN_MODE             | no       | debug      | Set to `release` for production                             |                                    |
-| RETRIEVE_BUCKET / UPLOAD_BUCKET | no | datasets | Buckets to generate the read / write scoped policies for | psi-retrieve-dev, psi-upload-dev   |
+| RETRIEVE_BUCKET      | no       | datasets   | Bucket to generate the read scoped policy for               | psi-retrieve-dev                    |
+| UPLOAD_BUCKET        | no       | datasets   | Bucket to generate the write scoped policy for              | psi-upload-dev                      |
 
 \* `SCICAT_URL` and `JOB_MANAGER_PASSWORD` are both _required_ for the `/datasets/urls` and `/publisheddata/urls` endpoints. If either is not set, the server returns `HTTP 501 Not Implemented`.
 

--- a/cmd/client/credential_process.go
+++ b/cmd/client/credential_process.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"time"
 
@@ -39,8 +40,16 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Prepare request
-	req, err := http.NewRequest("GET", *api+"?pid="+*dataset+"&operation="+*operation, nil)
+	baseURL, err := url.Parse(*api)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	q := baseURL.Query()
+	q.Set("pid", *dataset)
+	q.Set("operation", *operation)
+	baseURL.RawQuery = q.Encode()
+	req, err := http.NewRequest("GET", baseURL.String(), nil)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)

--- a/cmd/client/credential_process.go
+++ b/cmd/client/credential_process.go
@@ -26,6 +26,7 @@ func main() {
 	dataset := flag.String("dataset", "", "Dataset PID or ID")
 	token := flag.String("token", os.Getenv("SCICAT_TOKEN"), "SciCat access token")
 	api := flag.String("api", "http://localhost:8080/datasets/s3-creds", "SciCat S3 creds endpoint")
+	operation := flag.String("operation", "read", "operation to request: read or write")
 	flag.Parse()
 
 	if *dataset == "" || *token == "" {
@@ -33,8 +34,13 @@ func main() {
 		os.Exit(1)
 	}
 
+	if *operation != "read" && *operation != "write" {
+		fmt.Fprintln(os.Stderr, "operation must be 'read' or 'write'")
+		os.Exit(1)
+	}
+
 	// Prepare request
-	req, err := http.NewRequest("GET", *api+"?pid="+*dataset, nil)
+	req, err := http.NewRequest("GET", *api+"?pid="+*dataset+"&operation="+*operation, nil)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -42,7 +42,7 @@ func main() {
 	} else {
 		authorizer = auth.NewNoOpAuthorizer()
 	}
-	s3Handler := s3.NewHandler(authorizer)
+	s3Handler := s3.NewHandler(authorizer, cfg.BucketConfig)
 
 	if cfg.SciCatURL != "" && cfg.JobManagerPassword != "" {
 		var h api.ServerInterface = struct {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,12 +28,12 @@ func Load() (*Config, error) {
 		username = "jobManager"
 	}
 
-	retrieveBucket := os.Getenv("RETRIEVE_BUCKET")
+	retrieveBucket := strings.TrimSpace(os.Getenv("RETRIEVE_BUCKET"))
 	if retrieveBucket == "" {
 		retrieveBucket = "datasets"
 	}
 
-	uploadBucket := os.Getenv("UPLOAD_BUCKET")
+	uploadBucket := strings.TrimSpace(os.Getenv("UPLOAD_BUCKET"))
 	if uploadBucket == "" {
 		uploadBucket = "datasets"
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,10 +5,16 @@ import (
 	"strings"
 )
 
+type BucketConfig struct {
+	RetrieveBucket string
+	UploadBucket   string
+}
+
 type Config struct {
 	SciCatURL          string
 	JobManagerUsername string
 	JobManagerPassword string
+	BucketConfig       BucketConfig
 }
 
 // Load reads environment variables and validates them.
@@ -22,9 +28,20 @@ func Load() (*Config, error) {
 		username = "jobManager"
 	}
 
+	retrieveBucket := os.Getenv("RETRIEVE_BUCKET")
+	if retrieveBucket == "" {
+		retrieveBucket = "datasets"
+	}
+
+	uploadBucket := os.Getenv("UPLOAD_BUCKET")
+	if uploadBucket == "" {
+		uploadBucket = "datasets"
+	}
+
 	return &Config{
 		SciCatURL:          strings.TrimRight(scicatURL, "/"),
 		JobManagerUsername: username,
 		JobManagerPassword: password,
+		BucketConfig:       BucketConfig{RetrieveBucket: retrieveBucket, UploadBucket: uploadBucket},
 	}, nil
 }

--- a/internal/s3/policy.go
+++ b/internal/s3/policy.go
@@ -25,15 +25,18 @@ type policyCondition struct {
 
 // buildScopedPolicy returns an IAM policy JSON string that restricts access to
 // the given dataset and operation
-func buildScopedPolicy(dataset string, operation auth.Operation) (string, error) {
-	datasetArn := "arn:aws:s3:::datasets/" + dataset
-
+func (h *Handler) buildScopedPolicy(dataset string, operation auth.Operation) (string, error) {
 	var objectActions any
+	var bucket string
 	if operation == auth.OperationWrite {
 		objectActions = "s3:*"
+		bucket = h.bucketConfig.UploadBucket
 	} else {
 		objectActions = []string{"s3:Get*", "s3:List*"}
+		bucket = h.bucketConfig.RetrieveBucket
 	}
+
+	datasetArn := "arn:aws:s3:::" + bucket + "/" + dataset
 
 	doc := policyDocument{
 		Version: "2012-10-17",
@@ -46,7 +49,7 @@ func buildScopedPolicy(dataset string, operation auth.Operation) (string, error)
 			{
 				Effect:   "Allow",
 				Action:   "s3:ListBucket",
-				Resource: "arn:aws:s3:::datasets",
+				Resource: "arn:aws:s3:::" + bucket,
 				Condition: &policyCondition{
 					StringLike: map[string][]string{
 						"s3:prefix": {dataset + "/"},

--- a/internal/s3/policy.go
+++ b/internal/s3/policy.go
@@ -28,12 +28,18 @@ type policyCondition struct {
 func (h *Handler) buildScopedPolicy(dataset string, operation auth.Operation) (string, error) {
 	var objectActions any
 	var bucket string
-	if operation == auth.OperationWrite {
+	switch operation {
+	case auth.OperationWrite:
 		objectActions = "s3:*"
 		bucket = h.bucketConfig.UploadBucket
-	} else {
+	case auth.OperationRead:
 		objectActions = []string{"s3:Get*", "s3:List*"}
 		bucket = h.bucketConfig.RetrieveBucket
+	default:
+		return "", fmt.Errorf("invalid operation %v", operation)
+	}
+	if bucket == "" {
+		return "", fmt.Errorf("bucket is not configured")
 	}
 
 	datasetArn := "arn:aws:s3:::" + bucket + "/" + dataset

--- a/internal/s3/policy_test.go
+++ b/internal/s3/policy_test.go
@@ -6,31 +6,38 @@ import (
 	"testing"
 
 	"github.com/paulscherrerinstitute/scicat-s3-broker/internal/auth"
+	"github.com/paulscherrerinstitute/scicat-s3-broker/internal/config"
 )
 
 func TestBuildScopedPolicy(t *testing.T) {
 	dataset := "my-dataset"
+	retrieveBucket := "test-retrieve"
+	uploadBucket := "test-upload"
+	h := Handler{bucketConfig: config.BucketConfig{RetrieveBucket: retrieveBucket, UploadBucket: uploadBucket}}
 
 	tests := []struct {
 		name        string
 		operation   auth.Operation
 		wantActions any
+		wantBucket  string
 	}{
 		{
 			name:        "read grants restricted actions",
 			operation:   auth.OperationRead,
 			wantActions: []string{"s3:Get*", "s3:List*"},
+			wantBucket:  retrieveBucket,
 		},
 		{
 			name:        "write grants s3:*",
 			operation:   auth.OperationWrite,
 			wantActions: "s3:*",
+			wantBucket:  uploadBucket,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := buildScopedPolicy(dataset, tt.operation)
+			got, err := h.buildScopedPolicy(dataset, tt.operation)
 			if err != nil {
 				t.Fatalf("buildScopedPolicy() error = %v", err)
 			}
@@ -40,7 +47,7 @@ func TestBuildScopedPolicy(t *testing.T) {
 				t.Fatalf("output is not valid JSON: %v", err)
 			}
 
-			datasetARN := "arn:aws:s3:::datasets/" + dataset
+			datasetARN := "arn:aws:s3:::" + tt.wantBucket + "/" + dataset
 			stmt, ok := findStatementByResource(doc, datasetARN)
 			if !ok {
 				t.Fatalf("no statement found with resource %q", datasetARN)

--- a/internal/s3/s3_handler.go
+++ b/internal/s3/s3_handler.go
@@ -7,32 +7,34 @@ import (
 	"net/http"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
+	awsConfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/gin-gonic/gin"
 	"github.com/paulscherrerinstitute/scicat-s3-broker/internal/api"
 	"github.com/paulscherrerinstitute/scicat-s3-broker/internal/auth"
+	"github.com/paulscherrerinstitute/scicat-s3-broker/internal/config"
 )
 
 type Handler struct {
-	authorizer auth.Authorizer
-	stsClient  *sts.Client
+	authorizer   auth.Authorizer
+	stsClient    *sts.Client
+	bucketConfig config.BucketConfig
 }
 
-func NewHandler(authorizer auth.Authorizer) *Handler {
-	cfg, err := config.LoadDefaultConfig(context.TODO(),
-		config.WithSharedCredentialsFiles(
+func NewHandler(authorizer auth.Authorizer, bucketConfig config.BucketConfig) *Handler {
+	cfg, err := awsConfig.LoadDefaultConfig(context.TODO(),
+		awsConfig.WithSharedCredentialsFiles(
 			[]string{"env/credentials"},
 		),
-		config.WithSharedConfigFiles(
+		awsConfig.WithSharedConfigFiles(
 			[]string{"env/config"},
 		),
-		config.WithSharedConfigProfile("ceph"))
+		awsConfig.WithSharedConfigProfile("ceph"))
 	if err != nil {
 		log.Fatalf("Failed to load AWS config: %v", err)
 	}
 
-	return &Handler{authorizer: authorizer, stsClient: sts.NewFromConfig(cfg)}
+	return &Handler{authorizer: authorizer, stsClient: sts.NewFromConfig(cfg), bucketConfig: bucketConfig}
 }
 
 // GetDatasetsS3Creds handles the /datasets/s3-creds endpoint
@@ -51,7 +53,7 @@ func (h *Handler) GetDatasetsS3Creds(c *gin.Context, params api.GetDatasetsS3Cre
 		return
 	}
 
-	policy, err := buildScopedPolicy(dataset, operation)
+	policy, err := h.buildScopedPolicy(dataset, operation)
 	if err != nil {
 		log.Printf("Failed to build policy: %v", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal server error"})


### PR DESCRIPTION
Before, `buildScopedPolicy` granted read / write permissions always on the `datasets/pid` bucket. CSCS has now configured the buckets `psi-retrieve{-dev,-qa}` and `psi-upload{-dev,-qa}` to be accessible by PsiLimitedAccessRole.
Hence for `read`, read access is granted to `${RETRIEVE_BUCKET}/pid` and for `write`, write access is granted to `${UPLOAD_BUCKET}/pid`.

Also updated the `credential_process` client with an additional `operation` argument, which defaults to `read`.

We will also update the API response to include the S3 URI on which permissions are granted in a subsequent PR.


### Testing

Tested for
```
export UPLOAD_BUCKET=psi-upload-dev
export RETRIEVE_BUCKET=psi-retrieve-dev
```
and AWS config
```
[profile ceph_credential_process]
credential_process = ./credential_process --dataset 20.500.11935/931c08d7-1f86-47cd-9b48-56ae8173e4a8 --operation write
endpoint_url = https://rgw.cscs.ch
```

that we are able to both `ls` and `cp` to the upload bucket:
```
aws s3 --profile ceph_credential_process cp ./some-local-file s3://psi-upload-dev/20.500.11935/931c08d7-1f86-47cd-9b48-56ae8173e4a8/
```

and when configured with `--operation read` only `ls` is possible on the `psi-retrieve-dev` bucket.