### PR TITLE
Refactor API to be less SciCat-specific

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# SciCat S3 Broker Changelog
+
+Detailed changes are documented on [github release pages](https://github.com/paulscherrerinstitute/scicat-s3-broker/releases).
+
+API changes are document in the [OpenAPI Changelog](openapi/CHANGELOG.md)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # SciCat S3 Broker
 
-A lightweight service that brokers short-term S3 credentials for SciCat datasets.  
+A lightweight service that brokers short-term S3 credentials for SciCat datasets.
+This service implements the ETH S3 Data Exchange API.
 It delegates authorization to SciCat, then issues temporary, scoped S3 credentials
 (e.g. via Ceph STS) that clients can consume through the AWS SDK/CLI
 using the [`credential_process`](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sourcing-external.html) mechanism.
@@ -31,7 +32,7 @@ The following environement variables are available for configuration:
 
 | env var              | required | default    | description                                                 | example                            |
 | -------------------- | -------- | ---------- | ----------------------------------------------------------- | ---------------------------------- |
-| SCICAT_URL           | no\*    |            | SciCat backend base url                                     | https://scicat.development.psi.ch/ |
+| SCICAT_URL           | no\*     |            | SciCat backend base url                                     | https://scicat.development.psi.ch/ |
 | JOB_MANAGER_USERNAME | no       | jobManager | credentials for functional account to query /jobs in SciCat |                                    |
 | JOB_MANAGER_PASSWORD | no\*     | ""         |                                                             |                                    |
 | PORT                 | no       | 8080       | The port to serve from. This is a Gin configuration         |                                    |
@@ -39,9 +40,10 @@ The following environement variables are available for configuration:
 
 \* `SCICAT_URL` and `JOB_MANAGER_PASSWORD` are both _required_ for the `/datasets/urls` and `/publisheddata/urls` endpoints. If either is not set, the server returns `HTTP 501 Not Implemented`.
 
-If `SCICAT_URL` is set, `/datasets/s3-creds` validates the bearer token against SciCat via [SciCatAuthorizer](./internal/auth/scicat_authorizer.go). If unset, it uses [NoOpAuthorizer](./internal/auth/noop_authorizer.go) (no token validation).
+If `SCICAT_URL` is set, `/s3-creds` validates the bearer token against SciCat via [SciCatAuthorizer](./internal/auth/scicat_authorizer.go). If unset, it uses [NoOpAuthorizer](./internal/auth/noop_authorizer.go) (no token validation).
 
 #### AWS Config
+
 The AWS shared config and credentials files are in [env/](./env) directory. Copy `credentials.example` to `credentials` and replace with your secret / access key.
 
 ### Run locally
@@ -60,11 +62,11 @@ The server will start on port `8080` by default, or `${PORT}` env variable if sp
 
 Visit the OpenAPI explorer at http://localhost:8080/docs
 
-###### /datasets/s3-creds
+###### /s3-creds
 
 ```bash
 curl -H "Authorization: Bearer <scicat-token>" \
-  "http://localhost:8080/datasets/s3-creds?pid=PID12345"
+  "http://localhost:8080/s3-creds?id=PID12345"
 ```
 
 Response:
@@ -78,10 +80,10 @@ Response:
 }
 ```
 
-###### /datasets/urls
+###### /urls
 
 ```bash
-curl http://localhost:8080/datasets/urls?pid=20.500.11935/0e54729b-75c5-42fa-a628-aae5dc3f3dae
+curl http://localhost:8080/urls?id=20.500.11935/0e54729b-75c5-42fa-a628-aae5dc3f3dae
 ```
 
 Response:
@@ -100,14 +102,14 @@ Response:
 ```bash
 git clone https://github.com/paulscherrerinstitute/scicat-s3-broker.git
 cd scicat-s3-broker
-go run ./cmd/client/credential_process.go --dataset PID12345 --token <scicat-token> --api http://localhost:8085/datasets/s3-creds
+go run ./cmd/client/credential_process.go --dataset PID12345 --token <scicat-token> --api http://localhost:8085/s3-creds
 ```
 
 For use with AWS CLI and SDKs, build the client binary and configure your AWS profile to use it as a `credential_process`:
 
 ```bash
 go build ./cmd/client/credential_process.go
-./credential_process --dataset PID12345 --token <scicat-token> --api http://localhost:8080/datasets/s3-creds
+./credential_process --dataset PID12345 --token <scicat-token> --api http://localhost:8080/s3-creds
 ```
 
 Output:
@@ -136,8 +138,22 @@ cmd/            # main entrypoints
 internal/
     config/         # Server configuration
     api/            # Generated server interface and models
-    s3/             # S3 handlers and related functionality 
+    s3/             # S3 handlers and related functionality
     scicat/         # SciCat handlers and realted functionality
+```
+
+### OpenAPI changes
+
+After changing the API, regenerate api code with:
+
+```
+go generate ./...
+```
+
+### Tests
+
+```
+go test ./...
 ```
 
 ---

--- a/cmd/client/credential_process.go
+++ b/cmd/client/credential_process.go
@@ -25,7 +25,7 @@ type AWSCreds struct {
 func main() {
 	dataset := flag.String("dataset", "", "Dataset PID or ID")
 	token := flag.String("token", os.Getenv("SCICAT_TOKEN"), "SciCat access token")
-	api := flag.String("api", "http://localhost:8080/datasets/s3-creds", "SciCat S3 creds endpoint")
+	api := flag.String("api", "http://localhost:8080/s3-creds", "SciCat S3 creds endpoint")
 	flag.Parse()
 
 	if *dataset == "" || *token == "" {
@@ -34,7 +34,7 @@ func main() {
 	}
 
 	// Prepare request
-	req, err := http.NewRequest("GET", *api+"?pid="+*dataset, nil)
+	req, err := http.NewRequest("GET", *api+"?id="+*dataset, nil)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)

--- a/cmd/client/credential_process.go
+++ b/cmd/client/credential_process.go
@@ -12,7 +12,7 @@ import (
 	"github.com/paulscherrerinstitute/scicat-s3-broker/internal/api"
 )
 
-type SciCatCreds = api.S3CredentialsResponse
+type SciCatCreds = api.CredentialedUrlResponse
 
 type AWSCreds struct {
 	Version         int    `json:"Version"`
@@ -60,14 +60,15 @@ func main() {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
+	creds := sc.Credentials
 
 	// Convert to AWS credential_process format
 	aws := AWSCreds{
 		Version:         1,
-		AccessKeyID:     sc.AccessKey,
-		SecretAccessKey: sc.SecretAccessKey,
-		SessionToken:    sc.SessionToken,
-		Expiration:      sc.ExpiryTime.UTC().Format(time.RFC3339),
+		AccessKeyID:     creds.AccessKey,
+		SecretAccessKey: creds.SecretAccessKey,
+		SessionToken:    creds.SessionToken,
+		Expiration:      creds.ExpiryTime.UTC().Format(time.RFC3339),
 	}
 
 	enc := json.NewEncoder(os.Stdout)

--- a/internal/api/api.gen.go
+++ b/internal/api/api.gen.go
@@ -127,7 +127,7 @@ type GetUrlsParams struct {
 
 // ServerInterface represents all server handlers.
 type ServerInterface interface {
-	// Get download URLs for a dataset. Equivalent to `/urls?id={pid}` but returns a single URL.
+	// Get download URLs for a dataset. Equivalent to `/urls?id={pid}`.
 	// (GET /datasets/urls)
 	GetDatasetsUrls(c *gin.Context, params GetDatasetsUrlsParams)
 	// Get download URLs for a SciCat PublishedData entry, which may include multiple datasets

--- a/internal/api/api.gen.go
+++ b/internal/api/api.gen.go
@@ -16,15 +16,18 @@ const (
 	BearerAuthScopes bearerAuthContextKey = "BearerAuth.Scopes"
 )
 
-// Defines values for GetDatasetsS3CredsParamsOperation.
+// Defines values for GetS3CredsParamsOperation.
 const (
-	Read  GetDatasetsS3CredsParamsOperation = "read"
-	Write GetDatasetsS3CredsParamsOperation = "write"
+	Delete GetS3CredsParamsOperation = "delete"
+	Read   GetS3CredsParamsOperation = "read"
+	Write  GetS3CredsParamsOperation = "write"
 )
 
-// Valid indicates whether the value is a known member of the GetDatasetsS3CredsParamsOperation enum.
-func (e GetDatasetsS3CredsParamsOperation) Valid() bool {
+// Valid indicates whether the value is a known member of the GetS3CredsParamsOperation enum.
+func (e GetS3CredsParamsOperation) Valid() bool {
 	switch e {
+	case Delete:
+		return true
 	case Read:
 		return true
 	case Write:
@@ -34,11 +37,12 @@ func (e GetDatasetsS3CredsParamsOperation) Valid() bool {
 	}
 }
 
-// DatasetsUrlResponse defines model for DatasetsUrlResponse.
-type DatasetsUrlResponse struct {
-	// Expires The earliest expiration of all urls for this dataset
-	Expires time.Time `json:"expires"`
-	Urls    []UrlInfo `json:"urls"`
+// CredentialedUrlResponse defines model for CredentialedUrlResponse.
+type CredentialedUrlResponse struct {
+	Credentials S3CredentialsResponse `json:"credentials"`
+
+	// Uri s3 or https URI on which read/write permissions are granted
+	Uri string `json:"uri"`
 }
 
 // ErrorResponse defines model for ErrorResponse.
@@ -49,9 +53,9 @@ type ErrorResponse struct {
 
 // PublishedDataUrlsResponse defines model for PublishedDataUrlsResponse.
 type PublishedDataUrlsResponse struct {
-	// Expires The earliest expiration of all datasets' urls
-	Expires time.Time                      `json:"expires"`
-	Urls    map[string]DatasetsUrlResponse `json:"urls"`
+	// Expires The earliest expiration of all urls for this published data
+	Expires time.Time              `json:"expires"`
+	Urls    map[string]UrlInfoList `json:"urls"`
 }
 
 // S3CredentialsResponse defines model for S3CredentialsResponse.
@@ -69,29 +73,27 @@ type S3CredentialsResponse struct {
 	SessionToken string `json:"session_token"`
 }
 
-// UrlInfo defines model for UrlInfo.
+// UrlInfo Single URL with expiration
 type UrlInfo struct {
 	// Expires The expiration time of the URL in RFC 3339 format
 	Expires time.Time `json:"expires"`
 
-	// Url The URL to access the dataset
+	// Url The URI to access the dataset. This should use either the HTTP(S) or S3 protocol
 	Url string `json:"url"`
+}
+
+// UrlInfoList A list of URLs
+type UrlInfoList struct {
+	// Id identifier for the resource, if applicable
+	Id *string `json:"id,omitempty"`
+
+	// Expires The earliest expiration of all urls for this resource
+	Expires time.Time `json:"expires"`
+	Urls    []UrlInfo `json:"urls"`
 }
 
 // bearerAuthContextKey is the context key for BearerAuth security scheme
 type bearerAuthContextKey string
-
-// GetDatasetsS3CredsParams defines parameters for GetDatasetsS3Creds.
-type GetDatasetsS3CredsParams struct {
-	// Pid The unique identifier of the dataset
-	Pid string `form:"pid" json:"pid"`
-
-	// Operation The operation to request credentials for
-	Operation *GetDatasetsS3CredsParamsOperation `form:"operation,omitempty" json:"operation,omitempty"`
-}
-
-// GetDatasetsS3CredsParamsOperation defines parameters for GetDatasetsS3Creds.
-type GetDatasetsS3CredsParamsOperation string
 
 // GetDatasetsUrlsParams defines parameters for GetDatasetsUrls.
 type GetDatasetsUrlsParams struct {
@@ -105,17 +107,38 @@ type GetPublisheddataUrlsParams struct {
 	Id string `form:"id" json:"id"`
 }
 
+// GetS3CredsParams defines parameters for GetS3Creds.
+type GetS3CredsParams struct {
+	// Id The unique identifier of the resource for purposes of authorization
+	Id string `form:"id" json:"id"`
+
+	// Operation Requested authorization operation: read, write, or delete.
+	Operation *GetS3CredsParamsOperation `form:"operation,omitempty" json:"operation,omitempty"`
+}
+
+// GetS3CredsParamsOperation defines parameters for GetS3Creds.
+type GetS3CredsParamsOperation string
+
+// GetUrlsParams defines parameters for GetUrls.
+type GetUrlsParams struct {
+	// Id The id of the resource.
+	Id string `form:"id" json:"id"`
+}
+
 // ServerInterface represents all server handlers.
 type ServerInterface interface {
-	// Get temporary S3 credentials for a dataset
-	// (GET /datasets/s3-creds)
-	GetDatasetsS3Creds(c *gin.Context, params GetDatasetsS3CredsParams)
-	// Get download URLs for a dataset
+	// Get download URLs for a dataset. Equivalent to `/urls?id={pid}` but returns a single URL.
 	// (GET /datasets/urls)
 	GetDatasetsUrls(c *gin.Context, params GetDatasetsUrlsParams)
-	// Get download URLs for a published data
+	// Get download URLs for a SciCat PublishedData entry, which may include multiple datasets
 	// (GET /publisheddata/urls)
 	GetPublisheddataUrls(c *gin.Context, params GetPublisheddataUrlsParams)
+	// Get temporary S3 credentials for a resource.
+	// (GET /s3-creds)
+	GetS3Creds(c *gin.Context, params GetS3CredsParams)
+	// Get URLs for a resource.
+	// (GET /urls)
+	GetUrls(c *gin.Context, params GetUrlsParams)
 }
 
 // ServerInterfaceWrapper converts contexts to parameters.
@@ -126,43 +149,6 @@ type ServerInterfaceWrapper struct {
 }
 
 type MiddlewareFunc func(c *gin.Context)
-
-// GetDatasetsS3Creds operation middleware
-func (siw *ServerInterfaceWrapper) GetDatasetsS3Creds(c *gin.Context) {
-
-	var err error
-	_ = err
-
-	c.Set(string(BearerAuthScopes), []string{})
-
-	// Parameter object where we will unmarshal all parameters from the context
-	var params GetDatasetsS3CredsParams
-
-	// ------------- Required query parameter "pid" -------------
-
-	err = runtime.BindQueryParameterWithOptions("form", true, true, "pid", c.Request.URL.Query(), &params.Pid, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
-	if err != nil {
-		siw.ErrorHandler(c, fmt.Errorf("Invalid format for parameter pid: %w", err), http.StatusBadRequest)
-		return
-	}
-
-	// ------------- Optional query parameter "operation" -------------
-
-	err = runtime.BindQueryParameterWithOptions("form", true, false, "operation", c.Request.URL.Query(), &params.Operation, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
-	if err != nil {
-		siw.ErrorHandler(c, fmt.Errorf("Invalid format for parameter operation: %w", err), http.StatusBadRequest)
-		return
-	}
-
-	for _, middleware := range siw.HandlerMiddlewares {
-		middleware(c)
-		if c.IsAborted() {
-			return
-		}
-	}
-
-	siw.Handler.GetDatasetsS3Creds(c, params)
-}
 
 // GetDatasetsUrls operation middleware
 func (siw *ServerInterfaceWrapper) GetDatasetsUrls(c *gin.Context) {
@@ -218,6 +204,70 @@ func (siw *ServerInterfaceWrapper) GetPublisheddataUrls(c *gin.Context) {
 	siw.Handler.GetPublisheddataUrls(c, params)
 }
 
+// GetS3Creds operation middleware
+func (siw *ServerInterfaceWrapper) GetS3Creds(c *gin.Context) {
+
+	var err error
+	_ = err
+
+	c.Set(string(BearerAuthScopes), []string{})
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params GetS3CredsParams
+
+	// ------------- Required query parameter "id" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, true, "id", c.Request.URL.Query(), &params.Id, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandler(c, fmt.Errorf("Invalid format for parameter id: %w", err), http.StatusBadRequest)
+		return
+	}
+
+	// ------------- Optional query parameter "operation" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "operation", c.Request.URL.Query(), &params.Operation, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandler(c, fmt.Errorf("Invalid format for parameter operation: %w", err), http.StatusBadRequest)
+		return
+	}
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		middleware(c)
+		if c.IsAborted() {
+			return
+		}
+	}
+
+	siw.Handler.GetS3Creds(c, params)
+}
+
+// GetUrls operation middleware
+func (siw *ServerInterfaceWrapper) GetUrls(c *gin.Context) {
+
+	var err error
+	_ = err
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params GetUrlsParams
+
+	// ------------- Required query parameter "id" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, true, "id", c.Request.URL.Query(), &params.Id, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandler(c, fmt.Errorf("Invalid format for parameter id: %w", err), http.StatusBadRequest)
+		return
+	}
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		middleware(c)
+		if c.IsAborted() {
+			return
+		}
+	}
+
+	siw.Handler.GetUrls(c, params)
+}
+
 // GinServerOptions provides options for the Gin server.
 type GinServerOptions struct {
 	BaseURL      string
@@ -245,7 +295,8 @@ func RegisterHandlersWithOptions(router gin.IRouter, si ServerInterface, options
 		ErrorHandler:       errorHandler,
 	}
 
-	router.GET(options.BaseURL+"/datasets/s3-creds", wrapper.GetDatasetsS3Creds)
 	router.GET(options.BaseURL+"/datasets/urls", wrapper.GetDatasetsUrls)
 	router.GET(options.BaseURL+"/publisheddata/urls", wrapper.GetPublisheddataUrls)
+	router.GET(options.BaseURL+"/s3-creds", wrapper.GetS3Creds)
+	router.GET(options.BaseURL+"/urls", wrapper.GetUrls)
 }

--- a/internal/auth/scicat_authorizer.go
+++ b/internal/auth/scicat_authorizer.go
@@ -29,6 +29,7 @@ func (a *SciCatAuthorizer) Authorize(c *gin.Context, pid string, operation Opera
 	}
 	token := authHeader[7:]
 
+	// All operations require read
 	ownerGroup, err := a.scicatGetDataset(c.Request.Context(), pid, token)
 	if err != nil {
 		return err
@@ -36,7 +37,12 @@ func (a *SciCatAuthorizer) Authorize(c *gin.Context, pid string, operation Opera
 		return nil
 	}
 
-	return a.authorizeWrite(c.Request.Context(), ownerGroup, token)
+	if operation == OperationWrite {
+		return a.authorizeWrite(c.Request.Context(), ownerGroup, token)
+	}
+
+	// No delete allowed
+	return fmt.Errorf("unauthorized for operation %v", operation)
 }
 
 func (a *SciCatAuthorizer) authorizeWrite(ctx context.Context, ownerGroup string, token string) error {

--- a/internal/s3/s3_handler.go
+++ b/internal/s3/s3_handler.go
@@ -71,14 +71,25 @@ func (h *Handler) GetS3Creds(c *gin.Context, params api.GetS3CredsParams) {
 		return
 	}
 
-	response := api.S3CredentialsResponse{
+	creds := api.S3CredentialsResponse{
 		AccessKey:       *stsOut.Credentials.AccessKeyId,
 		SecretAccessKey: *stsOut.Credentials.SecretAccessKey,
 		SessionToken:    *stsOut.Credentials.SessionToken,
 		ExpiryTime:      *stsOut.Credentials.Expiration,
 	}
+	response := api.CredentialedUrlResponse{
+		Uri:         buildS3Uri(params.Id, operation),
+		Credentials: creds,
+	}
 
 	c.JSON(http.StatusOK, response)
+}
+
+// placeholder implementation of s3Uri
+func buildS3Uri(id string, op auth.Operation) string {
+	// TO-DO: change bucket name from `datasets` to ${UPLOAD_BUCKET} or ${RETRIEVE_BUCKET} based on `op`
+	// after https://github.com/paulscherrerinstitute/scicat-s3-broker/pull/42 is merged
+	return "s3://datasets/" + id + "/"
 }
 
 func parseOperation(op *api.GetS3CredsParamsOperation) (auth.Operation, error) {

--- a/internal/s3/s3_handler.go
+++ b/internal/s3/s3_handler.go
@@ -35,9 +35,9 @@ func NewHandler(authorizer auth.Authorizer) *Handler {
 	return &Handler{authorizer: authorizer, stsClient: sts.NewFromConfig(cfg)}
 }
 
-// GetDatasetsS3Creds handles the /datasets/s3-creds endpoint
-func (h *Handler) GetDatasetsS3Creds(c *gin.Context, params api.GetDatasetsS3CredsParams) {
-	dataset := params.Pid
+// GetS3Creds handles the /s3-creds endpoint
+func (h *Handler) GetS3Creds(c *gin.Context, params api.GetS3CredsParams) {
+	dataset := params.Id
 
 	operation, err := parseOperation(params.Operation)
 	if err != nil {
@@ -81,7 +81,7 @@ func (h *Handler) GetDatasetsS3Creds(c *gin.Context, params api.GetDatasetsS3Cre
 	c.JSON(http.StatusOK, response)
 }
 
-func parseOperation(op *api.GetDatasetsS3CredsParamsOperation) (auth.Operation, error) {
+func parseOperation(op *api.GetS3CredsParamsOperation) (auth.Operation, error) {
 	if op == nil {
 		return auth.OperationRead, nil
 	}

--- a/internal/s3/s3_handler_test.go
+++ b/internal/s3/s3_handler_test.go
@@ -17,26 +17,26 @@ func (m *mockAuthorizer) Authorize(_ *gin.Context, _ string, _ auth.Operation) e
 	return m.err
 }
 
-func TestS3Handler_GetDatasetsS3Creds(t *testing.T) {
+func TestS3Handler_GetS3Creds(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
-	invalidOp := api.GetDatasetsS3CredsParamsOperation("delete")
+	invalidOp := api.GetS3CredsParamsOperation("delete")
 
 	tests := []struct {
 		name       string
-		params     api.GetDatasetsS3CredsParams
+		params     api.GetS3CredsParams
 		authorizer auth.Authorizer
 		wantStatus int
 	}{
 		{
 			name:       "invalid operation returns 400",
-			params:     api.GetDatasetsS3CredsParams{Pid: "some-dataset", Operation: &invalidOp},
+			params:     api.GetS3CredsParams{Id: "some-dataset", Operation: &invalidOp},
 			authorizer: &mockAuthorizer{},
 			wantStatus: http.StatusBadRequest,
 		},
 		{
 			name:       "authorizer error returns 403",
-			params:     api.GetDatasetsS3CredsParams{Pid: "some-dataset"},
+			params:     api.GetS3CredsParams{Id: "some-dataset"},
 			authorizer: &mockAuthorizer{err: fmt.Errorf("internal auth error")},
 			wantStatus: http.StatusForbidden,
 		},
@@ -46,12 +46,12 @@ func TestS3Handler_GetDatasetsS3Creds(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			handler := &Handler{authorizer: tt.authorizer}
 
-			req := httptest.NewRequest(http.MethodGet, "/datasets/s3-creds", nil)
+			req := httptest.NewRequest(http.MethodGet, "/s3-creds", nil)
 			w := httptest.NewRecorder()
 			c, _ := gin.CreateTestContext(w)
 			c.Request = req
 
-			handler.GetDatasetsS3Creds(c, tt.params)
+			handler.GetS3Creds(c, tt.params)
 
 			if w.Code != tt.wantStatus {
 				t.Errorf("status = %d, want %d", w.Code, tt.wantStatus)

--- a/internal/scicat/datasets_handler.go
+++ b/internal/scicat/datasets_handler.go
@@ -13,8 +13,12 @@ type DatasetsHandler struct {
 	service DatasetsService
 }
 
-func (h *DatasetsHandler) GetDatasetsUrls(c *gin.Context, id api.GetDatasetsUrlsParams) {
-	datasetsUrlResp, err := h.service.GetUrls(c.Request.Context(), id.Pid)
+func (h *DatasetsHandler) GetDatasetsUrls(c *gin.Context, pid api.GetDatasetsUrlsParams) {
+	h.GetUrls(c, api.GetUrlsParams{Id: pid.Pid})
+}
+
+func (h *DatasetsHandler) GetUrls(c *gin.Context, id api.GetUrlsParams) {
+	datasetsUrlResp, err := h.service.GetUrls(c.Request.Context(), id.Id)
 
 	if err != nil {
 		if notAccErr, ok := errors.AsType[DatasetNotAccessibleError](err); ok {

--- a/internal/scicat/datasets_handler_test.go
+++ b/internal/scicat/datasets_handler_test.go
@@ -13,7 +13,7 @@ import (
 
 type mockService struct{}
 
-func (m *mockService) GetUrls(c context.Context, dataset string) (*api.DatasetsUrlResponse, error) {
+func (m *mockService) GetUrls(c context.Context, dataset string) (*api.UrlInfoList, error) {
 	switch dataset {
 	case "not-found":
 		return nil, DatasetNotFoundError{dataset}
@@ -22,7 +22,7 @@ func (m *mockService) GetUrls(c context.Context, dataset string) (*api.DatasetsU
 	case "internal-error":
 		return nil, fmt.Errorf("internal error")
 	default:
-		return &api.DatasetsUrlResponse{
+		return &api.UrlInfoList{
 			Urls: []api.UrlInfo{
 				{Url: "http://example.com/dataset1"},
 				{Url: "http://example.com/dataset2"},

--- a/internal/scicat/datasets_service.go
+++ b/internal/scicat/datasets_service.go
@@ -19,7 +19,7 @@ import (
 )
 
 type DatasetsService interface {
-	GetUrls(c context.Context, dataset string) (*api.DatasetsUrlResponse, error)
+	GetUrls(c context.Context, dataset string) (*api.UrlInfoList, error)
 }
 
 type DatasetsServiceImpl struct {
@@ -46,7 +46,7 @@ type SciCatLoginResponse struct {
 
 var unixEpoch = time.Unix(0, 0).UTC()
 
-func (s *DatasetsServiceImpl) GetUrls(c context.Context, dataset string) (*api.DatasetsUrlResponse, error) {
+func (s *DatasetsServiceImpl) GetUrls(c context.Context, dataset string) (*api.UrlInfoList, error) {
 
 	if err := s.isPublicAndExists(dataset); err != nil {
 		return nil, err
@@ -95,10 +95,10 @@ func (s *DatasetsServiceImpl) GetUrls(c context.Context, dataset string) (*api.D
 	}
 
 	if len(jobResp) == 0 {
-		return &api.DatasetsUrlResponse{Expires: unixEpoch, Urls: []api.UrlInfo{}}, nil
+		return &api.UrlInfoList{Expires: unixEpoch, Urls: []api.UrlInfo{}}, nil
 	}
 
-	datasetsUrlResp, err := toDatasetsUrlResponse(dataset, jobResp[0])
+	datasetsUrlResp, err := toUrlInfoList(dataset, jobResp[0])
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert to URL response: %v", err)
 	}
@@ -141,12 +141,12 @@ func getExpirationFromJobResponse(jobResp JobsResponse) (time.Time, error) {
 	return parsedTime.AddDate(0, 0, 7), nil
 }
 
-func toDatasetsUrlResponse(pid string, resp JobsResponse) (*api.DatasetsUrlResponse, error) {
+func toUrlInfoList(pid string, resp JobsResponse) (*api.UrlInfoList, error) {
 	if len(resp.JobResultObject.Result) == 0 {
 		return nil, errors.New("no URLs available in job response")
 	}
 
-	result := api.DatasetsUrlResponse{}
+	result := api.UrlInfoList{}
 	result.Expires = time.Time{} // use zero-time as sentinel for max
 
 	topLevelExpiration, err := getExpirationFromJobResponse(resp)

--- a/internal/scicat/datasets_service_test.go
+++ b/internal/scicat/datasets_service_test.go
@@ -31,7 +31,7 @@ func TestDatasetsServiceGetUrls(t *testing.T) {
 		mockJobsBody   string
 		wantErr        bool
 		wantErrIs      error
-		wantResult     api.DatasetsUrlResponse
+		wantResult     api.UrlInfoList
 	}{
 		{
 			name:           "Success",
@@ -46,7 +46,7 @@ func TestDatasetsServiceGetUrls(t *testing.T) {
                 }
             }]`, validTimeRFC3339Str, validTimeIso8601Str, expiresSeconds),
 			wantErr: false,
-			wantResult: api.DatasetsUrlResponse{
+			wantResult: api.UrlInfoList{
 				Urls: []api.UrlInfo{
 					{
 						Url:     fmt.Sprintf("s3://bucket/file?X-Amz-Date=%s&X-Amz-Expires=%v", validTimeIso8601Str, expiresSeconds),
@@ -92,7 +92,7 @@ func TestDatasetsServiceGetUrls(t *testing.T) {
 			mockJobsCode:   http.StatusOK,
 			mockJobsBody:   `[]`,
 			wantErr:        false,
-			wantResult:     api.DatasetsUrlResponse{},
+			wantResult:     api.UrlInfoList{},
 		},
 	}
 
@@ -149,7 +149,7 @@ func TestDatasetsServiceGetUrls(t *testing.T) {
 			}
 
 			if !tt.wantErr {
-				expectedNoJobsResp := api.DatasetsUrlResponse{Expires: unixEpoch, Urls: []api.UrlInfo{}}
+				expectedNoJobsResp := api.UrlInfoList{Expires: unixEpoch, Urls: []api.UrlInfo{}}
 				if len(result.Urls) > 0 && result.Urls[0].Url != tt.wantResult.Urls[0].Url {
 					t.Errorf("GetUrls() mismatch\ngot:  %+v\nwant: %+v", result, tt.wantResult)
 				} else if tt.name == "No Jobs Found" && !cmp.Equal(*result, expectedNoJobsResp) {
@@ -159,7 +159,7 @@ func TestDatasetsServiceGetUrls(t *testing.T) {
 		})
 	}
 }
-func TestToDatasetsUrlResponse(t *testing.T) {
+func TestToUrlInfoList(t *testing.T) {
 	now := time.Now().UTC()
 	validTimeIso8601Str := now.Format(iso8601Layout)
 	validTimeRFC3339Str := now.Format(time.RFC3339)
@@ -257,10 +257,10 @@ func TestToDatasetsUrlResponse(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			jobResp := makeJobResponse(t, tt.inputJSON)
-			got, err := toDatasetsUrlResponse(tt.pid, jobResp)
+			got, err := toUrlInfoList(tt.pid, jobResp)
 
 			if (err != nil) != tt.wantErr {
-				t.Errorf("toDatasetsUrlResponse() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("toUrlInfoList() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 

--- a/internal/scicat/not_impl_handler.go
+++ b/internal/scicat/not_impl_handler.go
@@ -12,6 +12,13 @@ type NotImplHandler struct{}
 func NewNoImplHandler() *NotImplHandler {
 	return &NotImplHandler{}
 }
+
+func (*NotImplHandler) GetUrls(c *gin.Context, _ api.GetUrlsParams) {
+	c.JSON(http.StatusNotImplemented, gin.H{
+		"error": "This endpoint is disabled",
+	})
+}
+
 func (*NotImplHandler) GetDatasetsUrls(c *gin.Context, _ api.GetDatasetsUrlsParams) {
 	c.JSON(http.StatusNotImplemented, gin.H{
 		"error": "This endpoint is disabled",

--- a/internal/scicat/published_data_service.go
+++ b/internal/scicat/published_data_service.go
@@ -58,7 +58,7 @@ func (s *PublisheddataServiceImpl) GetUrls(ctx context.Context, doi string) (*ap
 	}
 	type concurrentResult struct {
 		pid            string
-		datasetUrlResp *api.DatasetsUrlResponse
+		datasetUrlResp *api.UrlInfoList
 	}
 	resultSlice := make([]concurrentResult, len(publishedDataResp[0].DatasetPids))
 	g, ctx := errgroup.WithContext(ctx)
@@ -77,7 +77,7 @@ func (s *PublisheddataServiceImpl) GetUrls(ctx context.Context, doi string) (*ap
 	}
 	result := api.PublishedDataUrlsResponse{}
 	result.Expires = time.Time{}
-	result.Urls = make(map[string]api.DatasetsUrlResponse)
+	result.Urls = make(map[string]api.UrlInfoList)
 	for _, r := range resultSlice {
 		result.Urls[r.pid] = *r.datasetUrlResp
 		result.Expires = minTime(result.Expires, r.datasetUrlResp.Expires)

--- a/internal/scicat/published_data_service_test.go
+++ b/internal/scicat/published_data_service_test.go
@@ -21,12 +21,12 @@ var errMockDatasetsInternal = errors.New("internal error")
 var timeA = time.Now()
 var timeB = time.Now().AddDate(0, 0, 1)
 
-func (m *mockDatasetsServiceImpl) GetUrls(c context.Context, dataset string) (*api.DatasetsUrlResponse, error) {
+func (m *mockDatasetsServiceImpl) GetUrls(c context.Context, dataset string) (*api.UrlInfoList, error) {
 	switch dataset {
 	case "pid1":
-		return &api.DatasetsUrlResponse{Expires: timeA, Urls: []api.UrlInfo{{Url: "http://example.com/pid1"}}}, nil
+		return &api.UrlInfoList{Expires: timeA, Urls: []api.UrlInfo{{Url: "http://example.com/pid1"}}}, nil
 	case "pid2":
-		return &api.DatasetsUrlResponse{Expires: timeB, Urls: []api.UrlInfo{{Url: "http://example.com/pid2"}}}, nil
+		return &api.UrlInfoList{Expires: timeB, Urls: []api.UrlInfo{{Url: "http://example.com/pid2"}}}, nil
 	case "pid-no-urls":
 		return nil, DatasetNotFoundError{Pid: dataset}
 	default:
@@ -53,7 +53,7 @@ func TestPublisheddataServiceGetUrls(t *testing.T) {
 			wantErr: false,
 			wantResult: api.PublishedDataUrlsResponse{
 				Expires: timeA,
-				Urls: map[string]api.DatasetsUrlResponse{
+				Urls: map[string]api.UrlInfoList{
 					"pid1": {Expires: timeA, Urls: []api.UrlInfo{{Url: "http://example.com/pid1"}}},
 					"pid2": {Expires: timeB, Urls: []api.UrlInfo{{Url: "http://example.com/pid2"}}},
 				},

--- a/internal/scicat/publisheddata_handler_test.go
+++ b/internal/scicat/publisheddata_handler_test.go
@@ -24,7 +24,7 @@ func (m *mockPublisheddataSvc) GetUrls(ctx context.Context, doi string) (*api.Pu
 	case "internal-error":
 		return nil, errors.New("internal error")
 	default:
-		return &api.PublishedDataUrlsResponse{Urls: map[string]api.DatasetsUrlResponse{
+		return &api.PublishedDataUrlsResponse{Urls: map[string]api.UrlInfoList{
 			"pid123": {Urls: []api.UrlInfo{{Url: "http://example.com/publisheddata1"}}}}}, nil
 	}
 }

--- a/openapi/CHANGELOG.md
+++ b/openapi/CHANGELOG.md
@@ -1,0 +1,16 @@
+# API Changelog
+
+This documents changes to the API version. The S3 Broker code is versioned separately. See the top-level [CHANGELOG](../CHANGELOG.md) for info about software versions.
+
+
+## 0.2.0
+
+Significant change to the API to make it compatible with other software besides SciCat.
+
+- Add `/urls` endpoint, indended to replace `/datasets/urls`. Rename the `pid` parameter to `id`. The old endpoint is kept but moved to the 'SciCat' section.
+- Rename `/datasets/s3-creds` to `/s3-creds`.
+
+
+## 0.1.0
+
+Initial API version.

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -1,11 +1,77 @@
 openapi: 3.0.0
 info:
-  title: SciCat S3 Broker
-  version: 0.1.0
+  title: ETH S3 Data Exchange API
+  version: 0.2.0
+  description: |-
+    This represents the API for interoperable exchange of data between ETH-domain research data services. The S3 protocol is used for the actual data transfer. The endpoints are deliberately kept minimal, and are focused on converting service-specific concepts standard S3 queries.
+
+    Resources may consist of either a single file (an S3 object), a directory (an S3 prefix), or a list of several objects and prefixes.
+
+    Some resources may require authentication. Clients should provide an authorization token in the `Authorization: Bearer` header authenticating the user to the service.
+
+    This also includes SciCat-specific endpoints for convenience that are not included in the common specification. These use SciCat vocabulary:
+    - Datasets are identified by PID, and resolve to a single Url
+    - PublishedData are identified by id or DOI, and resolve to a map between dataset PIDs and URLs
+tags:
+  - name: discovery
+    description: Finding S3 information from service identifiers
+  - name: auth
+    description: Obtaining S3 credentials by authenticating against the service
+  - name: scicat
+    description: Endpoints specific to SciCat resources
+
 paths:
+  /urls:
+    get:
+      summary: Get URLs for a resource.
+      description: |-
+        Each resource is mapped to one or more URIs. URIs may include:
+          - HTTP(S) URL to particular files (`https://mysite)
+          - S3 URI to a bucket and object (`s3://bucket/file.tar`)
+          - S3 URI to a bucket and prefix (`s3://bucket/prefix`)
+      parameters:
+        - in: query
+          name: id
+          required: true
+          schema:
+            type: string
+          description: The id of the resource.
+      tags: [discovery]
+      responses:
+        "200":
+          description: A mapping of resource IDs to their URLs and expiration times
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UrlInfoList"
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: No resource with `id` was found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: The resource is not public or accessible with the provided credentials
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
   /datasets/urls:
     get:
-      summary: Get download URLs for a dataset
+      summary: Get download URLs for a dataset. Equivalent to `/urls?id={pid}` but returns a single URL.
+      tags: [scicat]
       parameters:
         - in: query
           name: pid
@@ -19,7 +85,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/DatasetsUrlResponse"
+                $ref: "#/components/schemas/UrlInfo"
         "400":
           description: Bad Request
           content:
@@ -46,7 +112,8 @@ paths:
                 $ref: "#/components/schemas/ErrorResponse"
   /publisheddata/urls:
     get:
-      summary: Get download URLs for a published data
+      summary: Get download URLs for a SciCat PublishedData entry, which may include multiple datasets
+      tags: [scicat]
       parameters:
         - in: query
           name: id
@@ -85,33 +152,41 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
-  /datasets/s3-creds:
+  /s3-creds:
     get:
-      summary: Get temporary S3 credentials for a dataset
+      summary: Get temporary S3 credentials for a resource.
+
+      description: |-
+        Obtain temporary S3 credentials for a resource. The authorization policy for different types of resources may depend on the configuration, which may include public access, checking an OIDC claim, or calling an external service such as SciCat.
+
+        Credentials are returned along with the resource URLs, avoiding a second call to `/urls`.
+
+      tags: [auth]
       security:
         - BearerAuth: []
       parameters:
         - in: query
-          name: pid
+          name: id
           required: true
           schema:
             type: string
-          description: The unique identifier of the dataset
+          description: The unique identifier of the resource for purposes of authorization
         - in: query
           name: operation
           required: false
           schema:
             type: string
-            enum: [read, write]
+            enum: ["read", "write", "delete"]
             default: read
-          description: The operation to request credentials for
+          description: "Requested authorization operation: read, write, or delete."
+
       responses:
         "200":
-          description: Temporary S3 credentials for the dataset
+          description: Temporary S3 credentials for the resource
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/S3CredentialsResponse"
+                $ref: "#/components/schemas/CredentialedUrlResponse"
         "400":
           description: Bad Request
           content:
@@ -119,7 +194,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
         "403":
-          description: Dataset not public or accessible
+          description: Resource not public or accessible
           content:
             application/json:
               schema:
@@ -130,14 +205,16 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+
 components:
   schemas:
     UrlInfo:
       type: object
+      description: Single URL with expiration
       properties:
         url:
           type: string
-          description: The URL to access the dataset
+          description: The URI to access the dataset. This should use either the HTTP(S) or S3 protocol
           x-order: 2
         expires:
           type: string
@@ -147,38 +224,45 @@ components:
       required:
         - url
         - expires
-    DatasetsUrlResponse:
+    UrlInfoList:
       type: object
+      description: A list of URLs
       properties:
+        id:
+          type: string
+          description: identifier for the resource, if applicable
+          example: "10.1234/example"
+          x-order: 1
         expires:
           type: string
           format: date-time
-          description: The earliest expiration of all urls for this dataset
-          x-order: 1
+          description: The earliest expiration of all urls for this resource
+          x-order: 2
         urls:
           type: array
           items:
             $ref: "#/components/schemas/UrlInfo"
-          x-order: 2
+          x-order: 3
       required:
-        - expires
         - urls
+        - expires
     PublishedDataUrlsResponse:
       type: object
       properties:
         expires:
           type: string
           format: date-time
-          description: The earliest expiration of all datasets' urls
+          description: The earliest expiration of all urls for this published data
           x-order: 1
         urls:
           type: object
           additionalProperties:
-            $ref: "#/components/schemas/DatasetsUrlResponse"
+            $ref: "#/components/schemas/UrlInfoList"
           x-order: 2
       required:
         - expires
         - urls
+
     S3CredentialsResponse:
       type: object
       properties:
@@ -200,6 +284,18 @@ components:
       - secret_access_key
       - session_token
       - expiry_time
+    CredentialedUrlResponse:
+      type: object
+      properties:
+        uri:
+          type: string
+          description: s3 or https URI on which read/write permissions are granted
+        credentials:
+          $ref: "#/components/schemas/S3CredentialsResponse"
+      required:
+      - uri
+      - credentials
+
     ErrorResponse:
       type: object
       properties:

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -70,7 +70,7 @@ paths:
                 $ref: "#/components/schemas/ErrorResponse"
   /datasets/urls:
     get:
-      summary: Get download URLs for a dataset. Equivalent to `/urls?id={pid}` but returns a single URL.
+      summary: Get download URLs for a dataset. Equivalent to `/urls?id={pid}`.
       tags: [scicat]
       parameters:
         - in: query
@@ -85,7 +85,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/UrlInfo"
+                $ref: "#/components/schemas/UrlInfoList"
         "400":
           description: Bad Request
           content:


### PR DESCRIPTION
This allows other services to use the same API.

API changes:

- Rename `/datasets/s3-creds` to `/s3-creds`.
- Add `/urls` endpoint, intended to replace `/datasets/urls`. Rename the `pid` parameter to `id`. The old endpoint is kept but moved to the 'SciCat' section.
- Distinguish IDs from URL prefixes, rather than assuming that one can be derived from the other. Return the id along with URLs.
- Support read, write, and delete operations in `/s3-creds`

Code has been regenerated and updated to match the new API spec.