### PR TITLE
fix: update jobs filter with new syntax

### DIFF
--- a/internal/scicat/datasets_service.go
+++ b/internal/scicat/datasets_service.go
@@ -267,13 +267,13 @@ func (s *DatasetsServiceImpl) getToken() (string, error) {
 func makeJobsFilter(pid string) ([]byte, error) {
 	filterQuery, err := json.Marshal(gin.H{
 		"where": gin.H{
-			"type":                      gin.H{"$in": []string{"retrieve", "public"}},
+			"type":                      gin.H{"$in": []string{"public"}},
 			"jobParams.option":          "URLs",
 			"statusCode":                "finishedSuccessful",
 			"jobParams.datasetList.pid": pid,
 		},
-		"sort": gin.H{"updatedAt": -1},
 		"limits": gin.H{
+			"sort":  gin.H{"updatedAt": "desc"},
 			"limit": 1,
 			"skip":  0,
 		}})


### PR DESCRIPTION
https://github.com/SciCatProject/backend/pull/2745 changed `sort` from a top level field in the filter to a property of `limits`. Updating accordingly.
Also limiting only to `public` retrieves, as we are only interested in public S3 urls, whereas `retrieve` jobs currently contain pre-signed URLs.