### PR TITLE
feat: add s3Uri to datasets and publisheddata urls response

### DIFF
--- a/internal/api/api.gen.go
+++ b/internal/api/api.gen.go
@@ -38,7 +38,12 @@ func (e GetDatasetsS3CredsParamsOperation) Valid() bool {
 type DatasetsUrlResponse struct {
 	// Expires The earliest expiration of all urls for this dataset
 	Expires time.Time `json:"expires"`
-	Urls    []UrlInfo `json:"urls"`
+
+	// S3Uri URL to the S3 prefix containing dataset's files
+	S3Uri *string `json:"s3Uri,omitempty"`
+
+	// Urls List of download URLs to the dataset's individual files
+	Urls []UrlInfo `json:"urls"`
 }
 
 // ErrorResponse defines model for ErrorResponse.

--- a/internal/scicat/datasets_service.go
+++ b/internal/scicat/datasets_service.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -141,6 +142,34 @@ func getExpirationFromJobResponse(jobResp JobsResponse) (time.Time, error) {
 	return parsedTime.AddDate(0, 0, 7), nil
 }
 
+func extractS3PrefixUri(fullUrl string, pid string) (*string, error) {
+	u, err := url.Parse(fullUrl)
+	if err != nil {
+		return nil, fmt.Errorf("extractS3PrefixUri: invalid URL: %w", err)
+	}
+
+	// path is like /bucket/PID.PREFIX/shortPID/filename...
+	// parts = ["", "bucket", "PID.PREFIX", "shortPID", "...rest"]
+	parts := strings.SplitN(u.Path, "/", 5)
+	if len(parts) < 5 {
+		return nil, fmt.Errorf("extractS3PrefixUri: URL path too short: %s", u.Path)
+	}
+	bucket := parts[1]
+	dirPath := parts[2] + "/" + parts[3]
+	if dirPath != pid {
+		return nil, fmt.Errorf("extractS3PrefixUri: path component %q does not match pid %q", dirPath, pid)
+	}
+
+	result := url.URL{
+		Scheme:   u.Scheme,
+		Host:     u.Host,
+		Path:     "/" + bucket + "/",
+		RawQuery: "prefix=" + pid,
+	}
+	ret := result.String()
+	return &ret, nil
+}
+
 func toDatasetsUrlResponse(pid string, resp JobsResponse) (*api.DatasetsUrlResponse, error) {
 	if len(resp.JobResultObject.Result) == 0 {
 		return nil, errors.New("no URLs available in job response")
@@ -161,6 +190,14 @@ func toDatasetsUrlResponse(pid string, resp JobsResponse) (*api.DatasetsUrlRespo
 			}
 			result.Urls = append(result.Urls, api.UrlInfo{Expires: expirationTime, Url: x.Url})
 			result.Expires = minTime(result.Expires, expirationTime)
+		}
+	}
+
+	if len(result.Urls) > 0 {
+		firstUrl := result.Urls[0].Url
+		result.S3Uri, err = extractS3PrefixUri(firstUrl, pid)
+		if err != nil {
+			log.Printf("failed to extract s3Uri %v", err)
 		}
 	}
 

--- a/internal/scicat/datasets_service_test.go
+++ b/internal/scicat/datasets_service_test.go
@@ -21,6 +21,7 @@ func TestDatasetsServiceGetUrls(t *testing.T) {
 	validTimeRFC3339Str := now.Format(time.RFC3339)
 	validTimeIso8601Str := now.Format(iso8601Layout)
 	expiresSeconds := 604800
+	publicS3Uri := "https://s3.example.com/thebucket/?prefix=pid.prefix/34-dsf-sdf3"
 
 	tests := []struct {
 		name           string
@@ -34,15 +35,15 @@ func TestDatasetsServiceGetUrls(t *testing.T) {
 		wantResult     api.DatasetsUrlResponse
 	}{
 		{
-			name:           "Success",
-			datasetPid:     "valid-pid",
+			name:           "Success presigned",
+			datasetPid:     "valid-pid-presigned",
 			mockPublicCode: http.StatusOK,
 			mockLoginCode:  http.StatusCreated,
 			mockJobsCode:   http.StatusOK,
 			mockJobsBody: fmt.Sprintf(`[{
 				"updatedAt": "%s",
                 "jobResultObject": {
-                    "result": [{"datasetId": "valid-pid", "url": "s3://bucket/file?X-Amz-Date=%s&X-Amz-Expires=%v"}]
+                    "result": [{"datasetId": "valid-pid-presigned", "url": "s3://bucket/file?X-Amz-Date=%s&X-Amz-Expires=%v"}]
                 }
             }]`, validTimeRFC3339Str, validTimeIso8601Str, expiresSeconds),
 			wantErr: false,
@@ -53,6 +54,28 @@ func TestDatasetsServiceGetUrls(t *testing.T) {
 						Expires: now.Add(time.Second * time.Duration(expiresSeconds)),
 					},
 				},
+			},
+		},
+		{
+			name:           "Success non-presigned (public bucket) returns S3Uri",
+			datasetPid:     "pid.prefix/34-dsf-sdf3",
+			mockPublicCode: http.StatusOK,
+			mockLoginCode:  http.StatusCreated,
+			mockJobsCode:   http.StatusOK,
+			mockJobsBody: fmt.Sprintf(`[{
+				"updatedAt": "%s",
+                "jobResultObject": {
+                    "result": [{"datasetId": "pid.prefix/34-dsf-sdf3", "url": "https://s3.example.com/thebucket/pid.prefix/34-dsf-sdf3/file.txt"}]
+                }
+            }]`, validTimeRFC3339Str),
+			wantErr: false,
+			wantResult: api.DatasetsUrlResponse{
+				Urls: []api.UrlInfo{
+					{
+						Url: "https://s3.example.com/thebucket/pid.prefix/34-dsf-sdf3/file.txt",
+					},
+				},
+				S3Uri: &publicS3Uri,
 			},
 		},
 		{
@@ -154,6 +177,15 @@ func TestDatasetsServiceGetUrls(t *testing.T) {
 					t.Errorf("GetUrls() mismatch\ngot:  %+v\nwant: %+v", result, tt.wantResult)
 				} else if tt.name == "No Jobs Found" && !cmp.Equal(*result, expectedNoJobsResp) {
 					t.Errorf("GetUrls() mismatch:\ndiff %v", cmp.Diff(*result, expectedNoJobsResp))
+				}
+				if tt.wantResult.S3Uri != nil {
+					if result.S3Uri == nil {
+						t.Errorf("GetUrls() expected S3Uri %q, got nil", *tt.wantResult.S3Uri)
+					} else if *result.S3Uri != *tt.wantResult.S3Uri {
+						t.Errorf("GetUrls() S3Uri mismatch\ngot:  %q\nwant: %q", *result.S3Uri, *tt.wantResult.S3Uri)
+					}
+				} else if result.S3Uri != nil {
+					t.Errorf("GetUrls() expected no S3Uri, got %q", *result.S3Uri)
 				}
 			}
 		})
@@ -282,6 +314,63 @@ func TestToDatasetsUrlResponse(t *testing.T) {
 					if !got.Expires.Equal(expectedExp) {
 						t.Errorf("Expected earliest expiration at the root of the response\nGot: %v\nWant: %v", got.Expires, expectedExp)
 					}
+				}
+			}
+		})
+	}
+}
+
+func TestExtractS3PrefixUri(t *testing.T) {
+	publicS3Uri := "https://s3.example.com/thebucket/?prefix=pid.prefix/34-dsf-sdf3"
+
+	tests := []struct {
+		name    string
+		fullUrl string
+		pid     string
+		want    *string
+		wantErr bool
+	}{
+		{
+			name:    "valid prefix/id pid",
+			fullUrl: "https://s3.example.com/thebucket/pid.prefix/34-dsf-sdf3/file.txt",
+			pid:     "pid.prefix/34-dsf-sdf3",
+			want:    &publicS3Uri,
+			wantErr: false,
+		},
+		{
+			name:    "path too short",
+			fullUrl: "https://s3.example.com/thebucket/pid.prefix/34-dsf-sdf3",
+			pid:     "pid.prefix/34-dsf-sdf3",
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name:    "pid mismatch",
+			fullUrl: "https://s3.example.com/thebucket/wrong.prefix/other-id/file.txt",
+			pid:     "pid.prefix/34-dsf-sdf3",
+			want:    nil,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := extractS3PrefixUri(tt.fullUrl, tt.pid)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("extractS3PrefixUri() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.want == nil && got != nil {
+				t.Errorf("extractS3PrefixUri() = %q, want nil", *got)
+				return
+			}
+			if tt.want != nil {
+				if got == nil {
+					t.Errorf("extractS3PrefixUri() = nil, want %q", *tt.want)
+					return
+				}
+				if *got != *tt.want {
+					t.Errorf("extractS3PrefixUri() = %q, want %q", *got, *tt.want)
 				}
 			}
 		})

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -155,11 +155,16 @@ components:
           format: date-time
           description: The earliest expiration of all urls for this dataset
           x-order: 1
+        s3Uri:
+          type: string
+          description: URL to the S3 prefix containing dataset's files
+          x-order: 2
         urls:
           type: array
+          description: List of download URLs to the dataset's individual files
           items:
             $ref: "#/components/schemas/UrlInfo"
-          x-order: 2
+          x-order: 3
       required:
         - expires
         - urls


### PR DESCRIPTION
Adding an optional field `s3Uri` to URL response. This field is populated when the URL in the jobs response is to a public bucket (i.e. not presigned), and matches the format `https://s3endpoint.ch/bucket-name/pid.prefix/shortPID/file_or_folder_structure`. The value of  `s3Uri` in this case is `https://s3endpoint.ch/bucket-name/?prefix=pid.prefix/shortPID`

We also explicitly check that `pid.prefix/shortPID == datasetPid`

----
Tested that response of http://localhost:8080/publisheddata/urls?id=10.83766%2Fb6b1dcb4-acfa-46d1-9c76-91cb6fd6140f
contains s3Uri for each of the datasets
```json
{
  "expires": "2026-06-24T10:53:15.315Z",
  "urls": {
    "20.500.11935/1027af4a-2364-49cd-9357-1530a2c62796": {
      "expires": "2026-06-24T10:53:15.315Z",
      "s3Uri": "https://rgw.cscs.ch/psi:psi-public-tar-dev/?prefix=20.500.11935/1027af4a-2364-49cd-9357-1530a2c62796",
      "urls": [
...
```